### PR TITLE
fix to preserve element width while dragging

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -110,6 +110,8 @@ angular.module("ngDraggable", [])
                         if(! _dragEnabled)return;
                         evt.preventDefault();
                         element.addClass('dragging');
+                        // fix to preserve element width while dragging 
+                        element.width(element.width());
                         offset = _privoffset(element); 
 
                         element.centerX = element[0].offsetWidth / 2;


### PR DESCRIPTION
Element position while dragging is "fixed".
To preserve element width, we need to set width before dragging.