### PR TITLE
Hover Zones, Hover Zone Ids, Custom Touch Delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ app.controller('MainCtrl', function ($scope) {
 ## Examples
 [`Drag and drop`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example.html).
 
+[`Hover Zone`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example-hoverZone.html).
+
 [`Re-ordering`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example-reorder.html).
 
 [`Cloning`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example-clone.html).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ngDraggable
 ===========
 
-This is a fork of the main project, all of the modifications here are intended to be merged back into the 
-['main project'] (https://github.com/fatlinesofcode/ngDraggable).
+This is a fork, all of the modifications here are intended to be merged back into the 
+[`main project`] (https://github.com/fatlinesofcode/ngDraggable).
 
 Drag and drop module for Angular JS with support for touch devices. [`demo`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example.html).
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 ngDraggable
 ===========
 
-This is a fork, all of the modifications here are intended to be merged back into the 
-[`main project`] (https://github.com/fatlinesofcode/ngDraggable).
-
 Drag and drop module for Angular JS with support for touch devices. [`demo`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example.html).
 
 ### Usage:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ngDraggable
 ===========
 
+This is a fork of the main project, all of the modifications here are intended to be merged back into the 
+['main project'] (https://github.com/fatlinesofcode/ngDraggable).
+
 Drag and drop module for Angular JS with support for touch devices. [`demo`](http://htmlpreview.github.io/?https://github.com/fatlinesofcode/ngDraggable/blob/master/example.html).
 
 ### Usage:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ngDraggable",
   "main": "ngDraggable.js",
-  "version": "0.0.3",
+  "version": "0.0.31",
   "homepage": "https://github.com/fatlinesofcode/ngDraggable",
   "ignore": [
     "**/.*",

--- a/example-hoverZone.html
+++ b/example-hoverZone.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html >
+<head>
+  <title>ngDraggable</title>
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootswatch/2.3.1/spruce/bootstrap.min.css">
+  <style>
+
+    
+
+  </style>
+</head>
+<body ng-app="ExampleApp" ng-controller="MainCtrl">
+
+
+
+
+ <div id="iPhoneDisplayContainer" style="display:auto;">
+    
+    <div ng-repeat="item in items" >
+            <div class="DragBox" ng-drag="true" 
+                ng-drag-data="item" 
+                ng-force-touch = "true"
+                ng-touch-delay="300">{{item.s}}
+        	</div>
+    </div> 
+    
+    <div class="hoverZone" ng-drop="true" ng-on-hover="dragAction($hoverid)" ng-hover-id="overzone1">Zone 1</div>
+    <div class="hoverZone" ng-drop="true" ng-on-hover="dragAction($hoverid)"  ng-hover-id="overzone2">Zone 2</div>
+  </div>
+
+  <link href="http://code.ionicframework.com/1.0.0-beta.13/css/ionic.css" rel="stylesheet">
+    <script src="http://code.ionicframework.com/1.0.0-beta.13/js/ionic.bundle.js"></script>
+  <script src="ngDraggable.js"></script>
+  <script>
+   angular.module('ExampleApp', ['ionic', 'ngDraggable'])
+  .controller('MainCtrl', function ($scope, $ionicScrollDelegate, $ionicSlideBoxDelegate) {
+
+    $scope.items = [{s:'a'},{s:'b'},{s:'c'},{s:'d'},{s:'e'}];
+
+   	$scope.dragAction = function(attributeCase){
+     
+        switch(attributeCase){
+       case 'overzone1':
+        	alert("hovering over zone 1");
+         	break;
+       case 'overzone2':
+            alert("hovering over zone 2");
+         	break;
+      }
+   }
+});
+  </script>
+</body>
+</html>

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -283,7 +283,7 @@ angular.module("ngDraggable", [])
 
                     var isTouching = function(mouseX, mouseY, dragElement) {
                         var touching= hitTest(mouseX, mouseY);
-                        if(!touching && onHoverExit) onHoverExit(scope, {$hover-exit-id:_hoverExitId});
+                        if(!touching && onHoverExit) onHoverExit(scope, {$hoverExitId:_hoverExitId});
                         if(touching && onHover) onHover(scope, {$hoverid: _hoverId});
                         updateDragStyles(touching, dragElement);
                         return touching;

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -253,7 +253,7 @@ angular.module("ngDraggable", [])
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
                         //add css class to drop element indicating that a drag has started
-                        //element.addClass('drag-in-progress');
+                        element.addClass('drag-in-progress');
                     };
                     var onDragMove = function(evt, obj) {
                         if(! _dropEnabled)return;
@@ -267,7 +267,7 @@ angular.module("ngDraggable", [])
                         if (isTouching(obj.x, obj.y, obj.element)) {
                             
                             //remove in progress css class when drag element touches drop element
-                            //element.removeClass('drag-in-progress');
+                            element.removeClass('drag-in-progress');
                             
                             // call the ngDraggable ngDragSuccess element callback
                            if(obj.callback){

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -91,11 +91,8 @@ angular.module("ngDraggable", [])
                     	_forceTouch = (newVal || 'true');
                     };
                     
-<<<<<<< Updated upstream
                     }
 
-=======
->>>>>>> Stashed changes
                     var isClickableElement = function (evt) {
                         return (
                                 angular.isDefined(angular.element(evt.target).attr("ng-click")) ||

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -87,17 +87,14 @@ angular.module("ngDraggable", [])
                     var onCenterAnchor = function (newVal, oldVal) {
                         if(angular.isDefined(newVal))
                         _centerAnchor = (newVal || 'true');
-<<<<<<< HEAD
                     };
                     var onForceTouch = function( newVal, oldVal) {
                     	if(angular.isDefined(newVal))
                     	_forceTouch = (newVal || 'true');
                     };
                     
-=======
                     }
 
->>>>>>> bf9cbd22452ce3da4b56eb130cb14d7cb9666e07
                     var isClickableElement = function (evt) {
                         return (
                                 angular.isDefined(angular.element(evt.target).attr("ng-click")) ||
@@ -171,7 +168,6 @@ angular.module("ngDraggable", [])
                         _mx = ngDraggable.getEventProp(evt, 'pageX');
                         _my = ngDraggable.getEventProp(evt, 'pageY');
 
-<<<<<<< HEAD
                          if (_centerAnchor) {
                              _tx = _mx - element.centerX - $window.pageXOffset;
                              _ty = _my - element.centerY - $window.pageYOffset;
@@ -179,14 +175,12 @@ angular.module("ngDraggable", [])
                          else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;
-=======
                         if (_centerAnchor) {
                             _tx = _mx - element.centerX - _dragOffset.left;
                             _ty = _my - element.centerY - _dragOffset.top;
                         } else {
                             _tx = _mx - _mrx - _dragOffset.left;
                             _ty = _my - _mry - _dragOffset.top;
->>>>>>> bf9cbd22452ce3da4b56eb130cb14d7cb9666e07
                         }
 
                         moveElement(_tx, _ty);
@@ -214,13 +208,10 @@ angular.module("ngDraggable", [])
                     };
 
                     var reset = function() {
-<<<<<<< HEAD
                         element.css({left:'',top:'', position:'', 'z-index':'', margin: ''});
                     };
-=======
                         element.css({transform:'', 'z-index':''});
                     }
->>>>>>> bf9cbd22452ce3da4b56eb130cb14d7cb9666e07
 
                     var moveElement = function (x, y) {
                         element.css({
@@ -419,13 +410,10 @@ angular.module("ngDraggable", [])
 
                             moveElement(obj.tx, obj.ty);
                         }
-<<<<<<< HEAD
                     };
-=======
 
                         _dragOffset = ngDraggable.getPrivOffset(element);
                     }
->>>>>>> bf9cbd22452ce3da4b56eb130cb14d7cb9666e07
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
 

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -262,10 +262,11 @@ angular.module("ngDraggable", [])
                         
                         // don't listen to drop events if this is the element being dragged
                         if (!_dropEnabled || _myid === obj.uid)return;
+                        
+                        //delay removal of style until isTouching returns true
+                        $timeout(function(){element.removeClass('drag-in-progress');}, 175);
+                        
                         if (isTouching(obj.x, obj.y, obj.element)) {
-                            
-                            //remove in progress css class when drag event ends
-                        element.removeClass('drag-in-progress');
                             
                             // call the ngDraggable ngDragSuccess element callback
                            if(obj.callback){

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -211,6 +211,41 @@ angular.module("ngDraggable", [])
             };
         }])
 
+		.directive('ngDragObserver',[ function(){
+			return {
+				restrict: 'A',
+				link: function (scope, element, attrs) {
+					
+					var initialize = function () {
+                        toggleListeners(true);
+                    };
+                    
+                    var toggleListeners = function (enable) {
+                        // remove listeners
+                        if (!enable)return;
+                        // add listeners
+                        scope.$on('draggable:start', onDragStart);
+                        scope.$on('draggable:end', onDragEnd);
+                    };
+                    
+                    var onDragStart = function(evt, obj) {
+                        //add css class to observer element indicating that a drag has started
+                        element.addClass('drag-in-progress');
+                    };
+                    
+                    var onDragEnd = function (evt, obj) {
+                        //delay removal of style until isTouching returns true
+                        element.removeClass('drag-in-progress');
+                    };
+                    
+                    initialize();
+					
+				}
+			
+			};
+		
+		}])
+
         .directive('ngDrop', ['$parse', '$timeout', '$window', 'ngDraggable', function ($parse, $timeout, $window, ngDraggable) {
             return {
                 restrict: 'A',

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -145,6 +145,7 @@ angular.module("ngDraggable", [])
                          if (_centerAnchor) {
                              _tx = _mx - element.centerX - $window.pageXOffset;
                              _ty = _my - element.centerY - $window.pageYOffset;
+                    	}
                         else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -263,12 +263,14 @@ angular.module("ngDraggable", [])
 
                     var onDragEnd = function (evt, obj) {
                         
+                        //remove in progress css class when drag event ends
+                            element.removeClass('drag-in-progress');
+                        
                         // don't listen to drop events if this is the element being dragged
                         if (!_dropEnabled || _myid === obj.uid)return;
                         if (isTouching(obj.x, obj.y, obj.element)) {
                             
-                            //remove in progress css class when drag element touches drop element
-                            element.removeClass('drag-in-progress');
+                            
                             
                             // call the ngDraggable ngDragSuccess element callback
                            if(obj.callback){

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -90,8 +90,6 @@ angular.module("ngDraggable", [])
                     	if(angular.isDefined(newVal))
                     	_forceTouch = (newVal || 'true');
                     };
-                    
-                    }
 
                     var isClickableElement = function (evt) {
                         return (

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -253,6 +253,9 @@ angular.module("ngDraggable", [])
                     var onDragStart = function(evt, obj) {
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
+                        //add css class to drop element indicating that a drag has started
+                        element.addClass('drag-in-progress');
+                        
                     }
                     var onDragMove = function(evt, obj) {
                         if(! _dropEnabled)return;
@@ -268,7 +271,9 @@ angular.module("ngDraggable", [])
                            if(obj.callback){
                                 obj.callback(obj);
                             }
-
+                            //remove in progress css class when drag element reaches drop
+                            element.removeClass('drag-in-progress');
+							
                             $timeout(function(){
                                 onDropCallback(scope, {$data: obj.data, $event: obj});
                             });
@@ -288,6 +293,7 @@ angular.module("ngDraggable", [])
                             element.addClass('drag-enter');
                             dragElement.addClass('drag-over');
                         }else{
+                            
                             element.removeClass('drag-enter');
                             dragElement.removeClass('drag-over');
                         }

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -260,14 +260,12 @@ angular.module("ngDraggable", [])
 
                     var onDragEnd = function (evt, obj) {
                         
-                        //remove in progress css class when drag event ends
-                            element.removeClass('drag-in-progress');
-                        
                         // don't listen to drop events if this is the element being dragged
                         if (!_dropEnabled || _myid === obj.uid)return;
                         if (isTouching(obj.x, obj.y, obj.element)) {
                             
-                            
+                            //remove in progress css class when drag event ends
+                        element.removeClass('drag-in-progress');
                             
                             // call the ngDraggable ngDragSuccess element callback
                            if(obj.callback){

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -38,7 +38,7 @@ angular.module("ngDraggable", [])
                     scope.value = attrs.ngDrag;
                     var _touchDelay = function(){ if(attrs.ngTouchDelay){ return parseInt(attrs.ngTouchDelay);} else{ return 100;}}; _touchDelay();
                     var offset,_centerAnchor=false,_mx,_my,_tx,_ty,_mrx,_mry;
-                    var _scrollAnchor = false, _forceTouch = false; 
+                    var _forceTouch = false; 
                     var _hasTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
                     var _pressEvents = 'touchstart mousedown';
                     var _moveEvents = 'touchmove mousemove';
@@ -86,11 +86,6 @@ angular.module("ngDraggable", [])
                     var onCenterAnchor = function (newVal, oldVal) {
                         if(angular.isDefined(newVal))
                         _centerAnchor = (newVal || 'true');
-                    }
-                    
-                    var onScrollAnchor = function( newVal, oldVal) {
-                    	if(angular.isDefined(newVal))
-                    	_scrollAnchor = (newVal || 'true');
                     }
                     var onForceTouch = function( newVal, oldVal) {
                     	if(angular.isDefined(newVal))
@@ -151,10 +146,6 @@ angular.module("ngDraggable", [])
                          if (_centerAnchor) {
                              _tx = _mx - element.centerX - $window.pageXOffset;
                              _ty = _my - element.centerY - $window.pageYOffset;
-                        }else if (_scrollAnchor){
-                        	_tx = evt.clientX;
-                        	_ty = evt.clientY;
-                        } 
                         else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -66,7 +66,6 @@ angular.module("ngDraggable", [])
                         scope.$on('$destroy', onDestroy);                       
                         scope.$watch(attrs.ngDrag, onEnableChange);                     
                         scope.$watch(attrs.ngCenterAnchor, onCenterAnchor);
-                        scope.$watch(attrs.ngScrollAnchor, onScrollAnchor);
                         scope.$watch(attrs.ngForceTouch, onForceTouch);
                         scope.$watch(attrs.ngDragData, onDragDataChange);
                         element.on(_pressEvents, onpress);
@@ -249,44 +248,45 @@ angular.module("ngDraggable", [])
                     };
                     var onEnableChange = function (newVal, oldVal) {
                         _dropEnabled=scope.$eval(newVal);
-                    }
+                    };
                     var onDragStart = function(evt, obj) {
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
                         //add css class to drop element indicating that a drag has started
-                        element.addClass('drag-in-progress');
-                        
-                    }
+                        //element.addClass('drag-in-progress');
+                    };
                     var onDragMove = function(evt, obj) {
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
-                    }
+                    };
 
                     var onDragEnd = function (evt, obj) {
                         
                         // don't listen to drop events if this is the element being dragged
                         if (!_dropEnabled || _myid === obj.uid)return;
                         if (isTouching(obj.x, obj.y, obj.element)) {
+                            
+                            //remove in progress css class when drag element touches drop element
+                            //element.removeClass('drag-in-progress');
+                            
                             // call the ngDraggable ngDragSuccess element callback
                            if(obj.callback){
                                 obj.callback(obj);
                             }
-                            //remove in progress css class when drag element reaches drop
-                            element.removeClass('drag-in-progress');
 							
                             $timeout(function(){
                                 onDropCallback(scope, {$data: obj.data, $event: obj});
                             });
                         }
                         updateDragStyles(false, obj.element);
-                    }
+                    };
 
                     var isTouching = function(mouseX, mouseY, dragElement) {
                         var touching= hitTest(mouseX, mouseY);
                         if(touching && onHover) onHover(scope, {$hoverid: _elementSwitchCase});
                         updateDragStyles(touching, dragElement);
                         return touching;
-                    }
+                    };
 
                     var updateDragStyles = function(touching, dragElement) {
                         if(touching){
@@ -297,7 +297,7 @@ angular.module("ngDraggable", [])
                             element.removeClass('drag-enter');
                             dragElement.removeClass('drag-over');
                         }
-                    }
+                    };
 
                     var hitTest = function(x, y) {
                         var bounds = ngDraggable.getPrivOffset(element);
@@ -307,7 +307,7 @@ angular.module("ngDraggable", [])
                                 && x <= bounds.right
                                 && y <= bounds.bottom
                                 && y >= bounds.top;
-                    }
+                    };
 
                     initialize();
                 }

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -408,7 +408,6 @@ angular.module("ngDraggable", [])
 
 
                         _dragOffset = ngDraggable.getPrivOffset(element);
-                    }
 
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -3,9 +3,9 @@
  * https://github.com/fatlinesofcode/ngDraggable
  */
 angular.module("ngDraggable", [])
-        .service('ngDraggable', ['$window', function($window) {
+        .service('ngDraggable', ['$window', function ($window) {
 
-            var isDef = function(val) { return typeof val !== 'undefined'; };
+            var isDef = function (val) { return typeof val !== 'undefined'; };
 
             this.getEventProp = function getEventProp(evt, prop, skipOriginal) {
                 if (isDef(evt.touches) && evt.touches[0]) {
@@ -28,7 +28,7 @@ angular.module("ngDraggable", [])
                     top: box.top + $window.pageYOffset - docElem[0].clientTop,
                     left: box.left + $window.pageXOffset - docElem[0].clientLeft
                 };
-            }
+            };
 
         }])
         .directive('ngDrag', ['$rootScope', '$parse', '$document', '$window', 'ngDraggable', function ($rootScope, $parse, $document, $window, ngDraggable) {
@@ -85,19 +85,19 @@ angular.module("ngDraggable", [])
                     var onCenterAnchor = function (newVal, oldVal) {
                         if(angular.isDefined(newVal))
                         _centerAnchor = (newVal || 'true');
-                    }
+                    };
                     var onForceTouch = function( newVal, oldVal) {
                     	if(angular.isDefined(newVal))
                     	_forceTouch = (newVal || 'true');
-                    }
+                    };
                     
                     var isClickableElement = function (evt) {
                         return (
-                                angular.isDefined(angular.element(evt.target).attr("ng-click"))
-                                || angular.isDefined(angular.element(evt.target).attr("ng-dblclick"))
-                                || angular.isDefined(angular.element(evt.target).attr("ng-cancel-drag"))
+                                angular.isDefined(angular.element(evt.target).attr("ng-click")) ||
+                                angular.isDefined(angular.element(evt.target).attr("ng-dblclick")) ||
+                                angular.isDefined(angular.element(evt.target).attr("ng-cancel-drag"))
                                 );
-                    }
+                    };
                     /*
                      * When the element is clicked start the drag behaviour
                      * On touch devices as a small delay so as not to prevent native window scrolling
@@ -123,12 +123,12 @@ angular.module("ngDraggable", [])
                             onlongpress(evt);
                         }
 
-                    }
+                    };
                     var cancelPress = function() {
                         clearTimeout(_pressTimer);
                         $document.off(_moveEvents, cancelPress);
                         $document.off(_releaseEvents, cancelPress);
-                    }
+                    };
                     var onlongpress = function(evt) {
                         if(! _dragEnabled)return;
                         evt.preventDefault();
@@ -154,7 +154,7 @@ angular.module("ngDraggable", [])
                         $document.on(_moveEvents, onmove);
                         $document.on(_releaseEvents, onrelease);
                         $rootScope.$broadcast('draggable:start', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data});
-                    }
+                    };
 
                     var onmove = function (evt) {
                         if (!_dragEnabled)return;
@@ -166,9 +166,6 @@ angular.module("ngDraggable", [])
                          if (_centerAnchor) {
                              _tx = _mx - element.centerX - $window.pageXOffset;
                              _ty = _my - element.centerY - $window.pageYOffset;
-                        }else if (_scrollAnchor){
-                        	 _tx = evt.clientX;
-                        	 _ty = evt.clientY;
                         }
                          else {
                              _tx = _mx - _mrx - $window.pageXOffset;
@@ -178,7 +175,7 @@ angular.module("ngDraggable", [])
                         moveElement(_tx, _ty);
 
                         $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid });
-                    }
+                    };
 
                     var onrelease = function(evt) {
                         if (!_dragEnabled)
@@ -189,7 +186,7 @@ angular.module("ngDraggable", [])
                         reset();
                         $document.off(_moveEvents, onmove);
                         $document.off(_releaseEvents, onrelease);
-                    }
+                    };
 
                     var onDragComplete = function(evt) {
                         if (!onDragSuccessCallback )return;
@@ -197,21 +194,21 @@ angular.module("ngDraggable", [])
                         scope.$apply(function () {
                             onDragSuccessCallback(scope, {$data: _data, $event: evt});
                         });
-                    }
+                    };
 
                     var reset = function() {
                         element.css({left:'',top:'', position:'', 'z-index':'', margin: ''});
-                    }
+                    };
 
                     var moveElement = function (x, y) {
                         element.css({
                             left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999
                             //,margin: '0'  don't monkey with the margin, 
                         });
-                    }
+                    };
                     initialize();
                 }
-            }
+            };
         }])
 
         .directive('ngDrop', ['$parse', '$timeout', '$window', 'ngDraggable', function ($parse, $timeout, $window, ngDraggable) {
@@ -306,15 +303,15 @@ angular.module("ngDraggable", [])
                         var bounds = ngDraggable.getPrivOffset(element);
                         bounds.right = bounds.left + element[0].offsetWidth;
                         bounds.bottom = bounds.top + element[0].offsetHeight;
-                        return  x >= bounds.left
-                                && x <= bounds.right
-                                && y <= bounds.bottom
-                                && y >= bounds.top;
+                        return  x >= bounds.left &&
+                                x <= bounds.right &&
+                                y <= bounds.bottom &&
+                                y >= bounds.top;
                     };
 
                     initialize();
                 }
-            }
+            };
         }])
         .directive('ngDragClone', ['$parse', '$timeout', function ($parse, $timeout) {
             return {
@@ -348,9 +345,9 @@ angular.module("ngDraggable", [])
                         img.off('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                       //  element.on('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                         img.on('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
-                    }
+                    };
                     var onDragStart = function(evt, obj, elm) {
-                        _allowClone=true
+                        _allowClone=true;
                         if(angular.isDefined(obj.data.allowClone)){
                             _allowClone=obj.data.allowClone;
                         }
@@ -363,28 +360,28 @@ angular.module("ngDraggable", [])
 
                             moveElement(obj.tx, obj.ty);
                         }
-                    }
+                    };
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
                             moveElement(obj.tx, obj.ty);
                         }
-                    }
+                    };
                     var onDragEnd = function(evt, obj) {
                         //moveElement(obj.tx,obj.ty);
                         if(_allowClone) {
                             reset();
                         }
-                    }
+                    };
 
                     var reset = function() {
                         element.css({left:0,top:0, position:'fixed', 'z-index':-1, visibility:'hidden'});
-                    }
+                    };
                     var moveElement = function(x,y) {
                         element.css({
                             left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999, 'visibility': 'visible'
                             //,margin: '0'  don't monkey with the margin, 
                         });
-                    }
+                    };
 
                     var absorbEvent_ = function (event) {
                         var e = event.originalEvent;
@@ -393,11 +390,11 @@ angular.module("ngDraggable", [])
                         e.cancelBubble = true;
                         e.returnValue = false;
                         return false;
-                    }
+                    };
 
                     initialize();
                 }
-            }
+            };
         }])
     .directive('ngPreventDrag', ['$parse', '$timeout', function ($parse, $timeout) {
         return {
@@ -426,11 +423,11 @@ angular.module("ngDraggable", [])
                     e.cancelBubble = true;
                     e.returnValue = false;
                     return false;
-                }
+                };
 
                 initialize();
             }
-        }
+        };
     }])
     .directive('ngCancelDrag', [function () {
         return {
@@ -438,5 +435,5 @@ angular.module("ngDraggable", [])
             link: function (scope, element, attrs) {
                 element.find('*').attr('ng-cancel-drag', 'ng-cancel-drag');
             }
-        }
+        };
     }]);

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -90,7 +90,7 @@ angular.module("ngDraggable", [])
                     	if(angular.isDefined(newVal))
                     	_forceTouch = (newVal || 'true');
                     };
-
+                    
                     var isClickableElement = function (evt) {
                         return (
                                 angular.isDefined(angular.element(evt.target).attr("ng-click")) ||
@@ -170,12 +170,6 @@ angular.module("ngDraggable", [])
                          else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;
-                        if (_centerAnchor) {
-                            _tx = _mx - element.centerX - _dragOffset.left;
-                            _ty = _my - element.centerY - _dragOffset.top;
-                        } else {
-                            _tx = _mx - _mrx - _dragOffset.left;
-                            _ty = _my - _mry - _dragOffset.top;
                         }
 
                         moveElement(_tx, _ty);
@@ -205,8 +199,6 @@ angular.module("ngDraggable", [])
                     var reset = function() {
                         element.css({left:'',top:'', position:'', 'z-index':'', margin: ''});
                     };
-                        element.css({transform:'', 'z-index':''});
-                    }
 
                     var moveElement = function (x, y) {
                         element.css({
@@ -405,10 +397,6 @@ angular.module("ngDraggable", [])
                             moveElement(obj.tx, obj.ty);
                         }
                     };
-
-
-                        _dragOffset = ngDraggable.getPrivOffset(element);
-
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
                             moveElement(obj.tx, obj.ty);

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -216,14 +216,15 @@ angular.module("ngDraggable", [])
                 restrict: 'A',
                 link: function (scope, element, attrs) {
                     scope.value = attrs.ngDrop;
-					var _elementSwitchCase = attrs.ngHoverId;
+					var _hoverId = attrs.ngHoverId;
+					var _hoverExitId = attrs.ngHoverExitId;
                     var _myid = scope.$id;
 
                     var _dropEnabled=false;
 
                     var onDropCallback = $parse(attrs.ngDropSuccess);// || function(){};
 					var onHover = $parse(attrs.ngOnHover);
-					
+					var onHoverExit = $parse(attrs.ngOnHoverExit);
                     var initialize = function () {
                         toggleListeners(true);
                     };
@@ -282,7 +283,8 @@ angular.module("ngDraggable", [])
 
                     var isTouching = function(mouseX, mouseY, dragElement) {
                         var touching= hitTest(mouseX, mouseY);
-                        if(touching && onHover) onHover(scope, {$hoverid: _elementSwitchCase});
+                        if(!touching && onHoverExit) onHoverExit(scope, {$hover-exit-id:_hoverExitId});
+                        if(touching && onHover) onHover(scope, {$hoverid: _hoverId});
                         updateDragStyles(touching, dragElement);
                         return touching;
                     };

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -45,10 +45,8 @@ angular.module("ngDraggable", [])
                     var _releaseEvents = 'touchend mouseup';
 
                     // to identify the element in order to prevent getting superflous events when a single element has both drag and drop directives on it.
-                    var _myid = scope.$id;
+                    var _myid = scope.$id; 
                     var _data = null;
-
-                    var _dragOffset = null;
 
                     var _dragEnabled = false;
 
@@ -65,8 +63,8 @@ angular.module("ngDraggable", [])
                         if (!enable)return;
                         // add listeners.
 
-                        scope.$on('$destroy', onDestroy);
-                        scope.$watch(attrs.ngDrag, onEnableChange);
+                        scope.$on('$destroy', onDestroy);                       
+                        scope.$watch(attrs.ngDrag, onEnableChange);                     
                         scope.$watch(attrs.ngCenterAnchor, onCenterAnchor);
                         scope.$watch(attrs.ngForceTouch, onForceTouch);
                         scope.$watch(attrs.ngDragData, onDragDataChange);
@@ -93,8 +91,11 @@ angular.module("ngDraggable", [])
                     	_forceTouch = (newVal || 'true');
                     };
                     
+<<<<<<< Updated upstream
                     }
 
+=======
+>>>>>>> Stashed changes
                     var isClickableElement = function (evt) {
                         return (
                                 angular.isDefined(angular.element(evt.target).attr("ng-click")) ||
@@ -138,11 +139,10 @@ angular.module("ngDraggable", [])
                         evt.preventDefault();
                         element.addClass('dragging');
                         offset = ngDraggable.getPrivOffset(element);
-                        _dragOffset = offset;
 
                         element.centerX = element[0].offsetWidth / 2;
-                        element.centerY = element[0].offsetHeight / 2;
-
+                        element.centerY = element[0].offsetHeight / 2;    
+                        
                         _mx = ngDraggable.getEventProp(evt, 'pageX');
                         _my = ngDraggable.getEventProp(evt, 'pageY');
                         _mrx = _mx - offset.left;
@@ -154,8 +154,8 @@ angular.module("ngDraggable", [])
                         else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;
-                        }
-
+                        }                        
+                        
                         $document.on(_moveEvents, onmove);
                         $document.on(_releaseEvents, onrelease);
                         $rootScope.$broadcast('draggable:start', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data});
@@ -175,12 +175,15 @@ angular.module("ngDraggable", [])
                          else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;
+<<<<<<< Updated upstream
                         if (_centerAnchor) {
                             _tx = _mx - element.centerX - _dragOffset.left;
                             _ty = _my - element.centerY - _dragOffset.top;
                         } else {
                             _tx = _mx - _mrx - _dragOffset.left;
                             _ty = _my - _mry - _dragOffset.top;
+=======
+>>>>>>> Stashed changes
                         }
 
                         moveElement(_tx, _ty);
@@ -210,13 +213,16 @@ angular.module("ngDraggable", [])
                     var reset = function() {
                         element.css({left:'',top:'', position:'', 'z-index':'', margin: ''});
                     };
+<<<<<<< Updated upstream
                         element.css({transform:'', 'z-index':''});
                     }
+=======
+>>>>>>> Stashed changes
 
                     var moveElement = function (x, y) {
                         element.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)','z-index': 99999
-                            //,margin: '0'  don't monkey with the margin,
+                            left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999
+                            //,margin: '0'  don't monkey with the margin, 
                         });
                     };
                     initialize();
@@ -308,7 +314,7 @@ angular.module("ngDraggable", [])
                     };
 
                     var onDragEnd = function (evt, obj) {
-
+                        
                         // don't listen to drop events if this is the element being dragged
                         if (!_dropEnabled || _myid === obj.uid)return;
                         
@@ -362,12 +368,11 @@ angular.module("ngDraggable", [])
                 }
             };
         }])
-        .directive('ngDragClone', ['$parse', '$timeout', 'ngDraggable', function ($parse, $timeout, ngDraggable) {
+        .directive('ngDragClone', ['$parse', '$timeout', function ($parse, $timeout) {
             return {
                 restrict: 'A',
                 link: function (scope, element, attrs) {
                     var img, _allowClone=true;
-                    var _dragOffset = null;
                     scope.clonedData = {};
                     var initialize = function () {
 
@@ -411,16 +416,15 @@ angular.module("ngDraggable", [])
                             moveElement(obj.tx, obj.ty);
                         }
                     };
+<<<<<<< Updated upstream
 
                         _dragOffset = ngDraggable.getPrivOffset(element);
                     }
+=======
+>>>>>>> Stashed changes
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
-
-                            _tx = obj.tx + _dragOffset.left;
-                            _ty = obj.ty + _dragOffset.top;
-
-                            moveElement(_tx, _ty);
+                            moveElement(obj.tx, obj.ty);
                         }
                     };
                     var onDragEnd = function(evt, obj) {
@@ -435,8 +439,8 @@ angular.module("ngDraggable", [])
                     };
                     var moveElement = function(x,y) {
                         element.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)', 'z-index': 99999, 'visibility': 'visible'
-                            //,margin: '0'  don't monkey with the margin,
+                            left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999, 'visibility': 'visible'
+                            //,margin: '0'  don't monkey with the margin, 
                         });
                     };
 

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -175,15 +175,12 @@ angular.module("ngDraggable", [])
                          else {
                              _tx = _mx - _mrx - $window.pageXOffset;
                              _ty = _my - _mry - $window.pageYOffset;
-<<<<<<< Updated upstream
                         if (_centerAnchor) {
                             _tx = _mx - element.centerX - _dragOffset.left;
                             _ty = _my - element.centerY - _dragOffset.top;
                         } else {
                             _tx = _mx - _mrx - _dragOffset.left;
                             _ty = _my - _mry - _dragOffset.top;
-=======
->>>>>>> Stashed changes
                         }
 
                         moveElement(_tx, _ty);
@@ -213,11 +210,8 @@ angular.module("ngDraggable", [])
                     var reset = function() {
                         element.css({left:'',top:'', position:'', 'z-index':'', margin: ''});
                     };
-<<<<<<< Updated upstream
                         element.css({transform:'', 'z-index':''});
                     }
-=======
->>>>>>> Stashed changes
 
                     var moveElement = function (x, y) {
                         element.css({
@@ -416,12 +410,11 @@ angular.module("ngDraggable", [])
                             moveElement(obj.tx, obj.ty);
                         }
                     };
-<<<<<<< Updated upstream
+
 
                         _dragOffset = ngDraggable.getPrivOffset(element);
                     }
-=======
->>>>>>> Stashed changes
+
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
                             moveElement(obj.tx, obj.ty);


### PR DESCRIPTION
The main modifications relate to hover zones. ngDrop can define a function when a dragged element is over top of a drop element, and can perform specific actions by providing a hover id on the ngDrop element. see this code pen for usage of drop zones and the bellow modifications "http://s.codepen.io/jfspencer/debug/jEPGGm?"

a couple other modifications
- added ng-touch-delay. defaults to 100ms as before (useful for syncing with other events like on-hold)
- added ng-force-touch, defaults to false (found useful when using tools like code pen)
- added css class drag-in-progress to ngDrop elements during drag (useful when drop elements need to be conditional on active drag)
- ran through jsLint and performed the recommended adjustments