### PR TITLE
Alternative to ng-cancel-drag - Explictly specifying what can be dragged.

### DIFF
--- a/example-initiator.html
+++ b/example-initiator.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ngDraggable</title>
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootswatch/2.3.1/spruce/bootstrap.min.css">
+    <style>
+
+
+
+* {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.widget {
+    height: 100px;
+    width: 100px;
+}
+
+.widget_top {
+    height: 20px;
+    display: block;
+}
+
+[ng-drag] {
+
+}
+
+.widget_body {
+    width: 100px;
+    height: 80px;
+    background: rgba(255, 0, 0, 0.5);
+    color: white;
+    text-align: center;
+    padding-top: 40px;
+    display: block;
+}
+
+[ng-drag] {
+    -moz-user-select: -moz-none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+
+[ng-drag] {
+    background: yellow;
+    height: 20px;
+    width: 20px;
+    cursor: -webkit-grab;
+}
+
+[ng-drag-contents].one {
+    background: rgba(255, 0, 0, 0.5);
+}
+
+[ng-drag-contents].two {
+    background: rgba(0, 255, 0, 0.5);
+}
+
+[ng-drag-contents].three {
+    background: rgba(0, 0, 255, 0.5);
+}
+
+[ng-drag-contents].drag-over {
+    border: solid 1px red;
+}
+
+[ng-drag-contents].dragging {
+    opacity: 0.5;
+    cursor: -webkit-grabbing;
+}
+
+[ng-drop] {
+    background: rgba(0, 0, 0, 0.25);
+    text-align: center;
+    display: block;
+    position: relative;
+    padding: 20px;
+    width: 140px;
+    height: 140px;
+    float: left;
+}
+
+[ng-drop].drag-enter {
+    border: solid 5px red;
+}
+
+[ng-drop] span.title {
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 200px;
+    height: 20px;
+    margin-left: -100px;
+    margin-top: -10px;
+}
+
+[ng-drop] div {
+    position: relative;
+    z-index: 2;
+}
+
+.draglist {
+    display: inline-block;
+    margin: 0 auto;
+}
+</style>
+</head>
+<body ng-app="ExampleApp">
+
+
+<div class="row  text-center">
+    <h1>ngDraggable Ordering Example</h1>
+</div>
+<hr/>
+
+<div class="row text-center" ng-controller="MainCtrl">
+    <ul class="draglist">
+        <li ng-repeat="obj in draggableObjects" ng-drop="true" ng-drop-success="onDropComplete($index, $data,$event)">
+            <div class="widget" ng-drag-content="true" > 
+            <div class="widget_top" ng-drag="true" ng-drag-data="obj" ></div>
+            <div class="widget_body" ng-class="obj.name">
+            
+                {{obj.name}}
+            </div>
+            </div>
+        </li>
+    </ul>
+</div>
+
+<hr/>
+
+<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.8/angular.min.js">
+
+</script>
+<script src="ngDraggable.js">
+
+</script>
+<script>
+
+
+angular.module('ExampleApp', ['ngDraggable']).
+controller('MainCtrl', function($scope) {
+    $scope.draggableObjects = [
+        {name: 'one'}, 
+        {name: 'two'}, 
+        {name: 'three'}
+    ];
+    $scope.onDropComplete = function(index, obj, evt) {
+        var otherObj = $scope.draggableObjects[index];
+        var otherIndex = $scope.draggableObjects.indexOf(obj);
+        $scope.draggableObjects[index] = obj;
+        $scope.draggableObjects[otherIndex] = otherObj;
+    }
+});
+</script>
+</body>
+</html>

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -220,7 +220,8 @@ angular.module("ngDraggable", [])
                     var moveElement = function (x, y) {
                             var dragContent = draggableElement(element);
                             dragContent.css({
-                            left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999
+                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)','z-index': 99999
+                            //,margin: '0'  don't monkey with the margin,
                         });
                     }
                     initialize();

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -231,7 +231,7 @@ angular.module("ngDraggable", [])
                 }
             }
         }])
-        
+
         .directive('ngDragContent', ['$log', 'ngDraggable', function ($log, ngDraggable) {
             return {
                 restrict: 'A',
@@ -241,7 +241,7 @@ angular.module("ngDraggable", [])
                      scope.draggableContent = element;
                 }
             }
-            
+
         }])
 
         .directive('ngDrop', ['$parse', '$timeout', '$window', 'ngDraggable', function ($parse, $timeout, $window, ngDraggable) {
@@ -289,7 +289,9 @@ angular.module("ngDraggable", [])
                     }
 
                     var onDragEnd = function (evt, obj) {
-
+                        // always clear the styles on drag end to ensure removal of
+                        // drag styles on the dragged element.
+                        updateDragStyles(false, obj.element);
                         // don't listen to drop events if this is the element being dragged
                         if (!_dropEnabled || _myid === obj.uid)return;
                         if (isTouching(obj.x, obj.y, obj.element)) {
@@ -302,7 +304,6 @@ angular.module("ngDraggable", [])
                                 onDropCallback(scope, {$data: obj.data, $event: obj});
                             });
                         }
-                        updateDragStyles(false, obj.element);
                     }
 
                     var isTouching = function(mouseX, mouseY, dragElement) {

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -158,11 +158,12 @@ angular.module("ngDraggable", [])
                         _mrx = _mx - offset.left;
                         _mry = _my - offset.top;
                          if (_centerAnchor) {
-                             _tx = _mx - element.centerX - $window.pageXOffset;
-                             _ty = _my - element.centerY - $window.pageYOffset;
+                            _tx = _mx - element.centerX - _dragOffset.left;
+                            _ty = _my - element.centerY - _dragOffset.top;
+
                         } else {
-                             _tx = _mx - _mrx - $window.pageXOffset;
-                             _ty = _my - _mry - $window.pageYOffset;
+                            _tx = _mx - _mrx - _dragOffset.left;
+                            _ty = _my - _mry - _dragOffset.top;
                         }
 
                         $document.on(_moveEvents, onmove);
@@ -178,11 +179,12 @@ angular.module("ngDraggable", [])
                         _my = ngDraggable.getEventProp(evt, 'pageY');
 
                         if (_centerAnchor) {
-                            _tx = _mx - element.centerX - _dragOffset.left;
-                            _ty = _my - element.centerY - _dragOffset.top;
+                             _tx = _mx - element.centerX - $window.pageXOffset;
+                             _ty = _my - element.centerY - $window.pageYOffset;
                         } else {
-                            _tx = _mx - _mrx - _dragOffset.left;
-                            _ty = _my - _mry - _dragOffset.top;
+                             _tx = _mx - _mrx - $window.pageXOffset;
+                             _ty = _my - _mry - $window.pageYOffset;
+
                         }
 
                         moveElement(_tx, _ty);
@@ -214,13 +216,14 @@ angular.module("ngDraggable", [])
 
                     var reset = function() {
                         var dragContent = draggableElement(element);
-                        dragContent.css({transform:'', 'z-index':''});
+                        dragContent.css({left:'',top:'', position:'', 'z-index':'', margin: ''});
+
                     }
 
                     var moveElement = function (x, y) {
                             var dragContent = draggableElement(element);
                             dragContent.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)','z-index': 99999
+                            left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999
                             //,margin: '0'  don't monkey with the margin,
                         });
                     }
@@ -385,11 +388,8 @@ angular.module("ngDraggable", [])
                     }
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
+                            moveElement(obj.tx, obj.ty);
 
-                            _tx = obj.tx + _dragOffset.left;
-                            _ty = obj.ty + _dragOffset.top;
-
-                            moveElement(_tx, _ty);
                         }
                     }
                     var onDragEnd = function(evt, obj) {
@@ -404,7 +404,8 @@ angular.module("ngDraggable", [])
                     }
                     var moveElement = function(x,y) {
                         element.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)', 'z-index': 99999, 'visibility': 'visible'
+                            left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999, 'visibility': 'visible'
+
                             //,margin: '0'  don't monkey with the margin,
                         });
                     }

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -304,6 +304,8 @@ angular.module("ngDraggable", [])
                                 onDropCallback(scope, {$data: obj.data, $event: obj});
                             });
                         }
+                        // make a subsequent call in case the object has moved.
+                        updateDragStyles(false, obj.element);
                     }
 
                     var isTouching = function(mouseX, mouseY, dragElement) {

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -220,8 +220,7 @@ angular.module("ngDraggable", [])
                     var moveElement = function (x, y) {
                             var dragContent = draggableElement(element);
                             dragContent.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)','z-index': 99999
-                            //,margin: '0'  don't monkey with the margin,
+                            left: (x+'px'), top: (y+'px'), position: 'fixed', 'z-index': 99999
                         });
                     }
                     initialize();


### PR DESCRIPTION
Hi, this change should support dragging a specific element vs. having to use ng-cancel-drag on every element within the drag which doesn't work very well for grids.

I included an example.  example-initiator.html.   The yellow box is the drag area.  It will drag the entire widget.