### PR TITLE
Added -webkit-transform to css transform operations.

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -190,12 +190,13 @@ angular.module("ngDraggable", [])
                     }
 
                     var reset = function() {
-                        element.css({transform:'', 'z-index':''});
+                        element.css({transform:'', 'z-index':'', '-webkit-transform':''});
                     }
 
                     var moveElement = function (x, y) {
                         element.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)','z-index': 99999
+                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)','z-index': 99999,
+                            '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)'
                             //,margin: '0'  don't monkey with the margin,
                         });
                     }
@@ -380,7 +381,8 @@ angular.module("ngDraggable", [])
                     };
                     var moveElement = function(x,y) {
                         element.css({
-                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)', 'z-index': 99999, 'visibility': 'visible'
+                            transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)', 'z-index': 99999, 'visibility': 'visible',
+                            '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)'
                             //,margin: '0'  don't monkey with the margin,
                         });
                     }


### PR DESCRIPTION
-webkit-transform is needed for older browsers/webkits that do not support the native css3 transform. This is especially needed for Cordova apps which target older webkits on iOS and Android.