### PR TITLE
Configurable debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Note: ng-center-anchor is optional. If not specified, it defaults to false.
 
 ```draggable:start```, ```draggable:move``` and  ```draggable:end``` events are broadcast on drag actions.
 
+
 Drop area usage:
 ```html
 <div ng-drop="true" ng-drop-success="onDropComplete($data,$event)" >

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ Draggable usage:
 ```
 Note: ng-center-anchor is optional. If not specified, it defaults to false.
 
-```ng-drag-start``` and ```ng-drag-move``` is also available. Add to the ng-drop element.
-``ng-drag-stop`` can be used when you want to react to the user dragging an item and it wasn't dropped into the target container.
-
-```draggable:start```, ```draggable:move``` and  ```draggable:end``` events are broadcast on drag actions.
-
-
 Drop area usage:
 ```html
 <div ng-drop="true" ng-drop-success="onDropComplete($data,$event)" >
@@ -54,6 +48,16 @@ app.controller('MainCtrl', function ($scope) {
         console.log("drop success, data:", data);
     }
  };
+```
+
+### Config
+
+To turn debug logging on, call `setDebugLogging` on the provider:
+
+```js
+yourApp.config(function (ngDraggableProvider) {
+  ngDraggableProvider.setDebugLogging(true);
+});
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Draggable usage:
 ```
 Note: ng-center-anchor is optional. If not specified, it defaults to false.
 
+```ng-drag-start``` and ```ng-drag-move``` is also available. Add to the ng-drop element.
+``ng-drag-stop`` can be used when you want to react to the user dragging an item and it wasn't dropped into the target container.
+
+```draggable:start```, ```draggable:move``` and  ```draggable:end``` events are broadcast on drag actions.
+
 Drop area usage:
 ```html
 <div ng-drop="true" ng-drop-success="onDropComplete($data,$event)" >

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -3,14 +3,26 @@
  * https://github.com/fatlinesofcode/ngDraggable
  */
 angular.module("ngDraggable", [])
-        .service('ngDraggable', [function() {
+        .provider('ngDraggable', [function(){
+            var logToConsole;
+            console || (console = {log : function(){}});
 
+            this.setDebugLogging = function(shouldLog) {
+                logToConsole = shouldLog;
+            };
 
-            var scope = this;
-            scope.inputEvent = function(event) {
-                return angular.isDefined(event.touches) ? event.touches[0] : event;
-            }
-
+            this.$get = function() {
+                return {
+                    inputEvent : function(event) {
+                        return angular.isDefined(event.touches) ? event.touches[0] : event;
+                    },
+                    log : function() {
+                        if (logToConsole) {
+                            console.log.apply(console, arguments);
+                        }
+                    }
+                }
+            };
         }])
         .directive('ngDrag', ['$rootScope', '$parse', '$document', '$window', 'ngDraggable', function ($rootScope, $parse, $document, $window, ngDraggable) {
             return {
@@ -37,7 +49,7 @@ angular.module("ngDraggable", [])
                     var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
                     var allowTransform = angular.isDefined(attrs.allowTransform) ? scope.$eval(attrs.allowTransform) : true;
 
-                    console.log("40","scope","link",  angular.isDefined(attrs.allowTransform) , allowTransform);
+                    ngDraggable.log("40","scope","link",  angular.isDefined(attrs.allowTransform) , allowTransform);
 
                     var initialize = function () {
                         element.attr('draggable', 'false'); // prevent native drag
@@ -63,7 +75,7 @@ angular.module("ngDraggable", [])
                             _dragHandle.on(_pressEvents, onpress);
                         } else {
                             // no handle(s) specified, use the element as the handle
-                            element.on(_pressEvents, onpress);    
+                            element.on(_pressEvents, onpress);
                         }
                         if(! _hasTouch && element[0].nodeName.toLowerCase() == "img"){
                             element.on('mousedown', function(){ return false;}); // prevent native drag for images
@@ -263,7 +275,7 @@ angular.module("ngDraggable", [])
                     var onDragStart = function(evt, obj) {
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
-                        
+
                         $timeout(function(){
                             onDragStartCallback(scope, {$data: obj.data, $event: obj});
                         });
@@ -280,7 +292,7 @@ angular.module("ngDraggable", [])
 
                         // don't listen to drop events if this is the element being dragged
                         // only update the styles and return
-                        console.log("266","onDragEnd","onDragEnd", _myid, obj.uid);
+                        ngDraggable.log("266","onDragEnd","onDragEnd", _myid, obj.uid);
                         if (!_dropEnabled || _myid === obj.uid) {
                             updateDragStyles(false, obj.element);
                             return;


### PR DESCRIPTION
To handle the issue of production logging (#102 and #104), I created a provider which can turn toggling on or off (default: off). The user can set it in their config:

```js
yourApp.config(function (ngDraggableProvider) {
  ngDraggableProvider.setDebugLogging(true);
});
```

It could be helpful for users encountering dragging problems to see debug logs, especially if/when this code grows. That's why I opted for this approach over simply removing the existing logs.

Also, it provides a fallback if console.log isn't defined (:boom: IE9 :boom:).