### PR TITLE
Avoiding digest cycles for undefined callbacks

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -272,17 +272,22 @@ angular.module("ngDraggable", [])
                     var onDragStart = function(evt, obj) {
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
-                        
-                        $timeout(function(){
-                            onDragStartCallback(scope, {$data: obj.data, $event: obj});
-                        });
+
+                        if (attrs.ngDragStart) {
+                            $timeout(function(){
+                                onDragStartCallback(scope, {$data: obj.data, $event: obj});
+                            });
+                        }
                     };
                     var onDragMove = function(evt, obj) {
                         if(! _dropEnabled)return;
                         isTouching(obj.x,obj.y,obj.element);
-                        $timeout(function(){
-                            onDragMoveCallback(scope, {$data: obj.data, $event: obj});
-                        });
+
+                        if (attrs.ngDragMove) {
+                            $timeout(function(){
+                                onDragMoveCallback(scope, {$data: obj.data, $event: obj});
+                            });
+                        }
                     };
 
                     var onDragEnd = function (evt, obj) {
@@ -299,13 +304,19 @@ angular.module("ngDraggable", [])
                                 obj.callback(obj);
                             }
 
+                            if (attrs.ngDropSuccess) {
+                                $timeout(function(){
+                                    onDropCallback(scope, {$data: obj.data, $event: obj, $target: scope.$eval(scope.value)});
+                                });
+                            }
+                        }
+
+                        if (attrs.ngDragStop) {
                             $timeout(function(){
-                                onDropCallback(scope, {$data: obj.data, $event: obj, $target: scope.$eval(scope.value)});
+                                onDragStopCallback(scope, {$data: obj.data, $event: obj});
                             });
                         }
-                        $timeout(function(){
-                            onDragStopCallback(scope, {$data: obj.data, $event: obj});
-                        });
+
                         updateDragStyles(false, obj.element);
                     };
 


### PR DESCRIPTION
I have a lot of elements that are droppable. The way that $timeout is currently used to call the ng-drop callback functions, it produces one digest cycle per ng-drop element per event, even for those elements that do not have a callback function defined for this event. This is particularly bad for the ng-drag-move callback function, as it is called on every pixel the mouse moves.

This patch avoids a digest cycle when no callback is defined.