### PR TITLE
Add support for a scale attribute to be provided to the ng-drag directiv...

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -17,6 +17,8 @@ angular.module("ngDraggable", [])
                 restrict: 'A',
                 link: function (scope, element, attrs) {
                     scope.value = attrs.ngDrag;
+                    //Default scaling to 1 none is provided
+                    var _scale = attrs.ngScale || 1;
                     var offset,_centerAnchor=false,_mx,_my,_tx,_ty,_mrx,_mry;
                     var _hasTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
                     var _pressEvents = 'touchstart mousedown';
@@ -212,10 +214,10 @@ angular.module("ngDraggable", [])
                     var moveElement = function (x, y) {
                         if(allowTransform) {
                             element.css({
-                                transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
+                                transform: 'matrix3d('+_scale+', 0, 0, 0, 0, '+_scale+', 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
                                 'z-index': 99999,
-                                '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
-                                '-ms-transform': 'matrix(1, 0, 0, 1, ' + x + ', ' + y + ')'
+                                '-webkit-transform': 'matrix3d('+_scale+', 0, 0, 0, 0, '+_scale+', 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
+                                '-ms-transform': 'matrix('+_scale+', 0, 0, '+_scale+', ' + x + ', ' + y + ')'
                             });
                         }else{
                             element.css({'left':x+'px','top':y+'px', 'position':'fixed'});


### PR DESCRIPTION
...e. This scales the image down or up to the ratio supplied. I left out support for x/y scaling as separate, but that could easily be added later.

I don't have easy access to IE, so you might wanna check that one to ensure it works correctly. I've confirmed it works fine on Firefox/Chrome.
