### PR TITLE
Use document instead of $document

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -343,8 +343,8 @@ angular.module("ngDraggable", [])
 
                     var hitTest = function(x, y) {
                         var bounds = element[0].getBoundingClientRect();// ngDraggable.getPrivOffset(element);
-                        x -= $document.body.scrollLeft + $document.documentElement.scrollLeft;
-                        y -= $document.body.scrollTop + $document.documentElement.scrollTop;
+                        x -= document.body.scrollLeft + document.documentElement.scrollLeft;
+                        y -= document.body.scrollTop + document.documentElement.scrollTop;
                         return  x >= bounds.left
                                 && x <= bounds.right
                                 && y <= bounds.bottom


### PR DESCRIPTION
Reverts commit 3963afb8. Fixes #133. Supersedes #136, which doesn’t take into consideration that neither $document.body nor $document.documentElement exist.