### PR TITLE
Do not start dragging on right click

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -100,6 +100,11 @@ angular.module("ngDraggable", [])
                             return;
                         }
 
+                        if (evt.type == "mousedown" && evt.button != 0) {
+                            // Do not start dragging on right-click
+                            return;
+                        }
+
                         if(_hasTouch){
                             cancelPress();
                             _pressTimer = setTimeout(function(){


### PR DESCRIPTION
At the moment, when right-clicking a draggable element, the context menu opens and dragging starts. This patch enables dragging only on left click.