### PR TITLE
Use $watch instead of $observe for ng-drop

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -256,7 +256,7 @@ angular.module("ngDraggable", [])
 
                         if (!enable)return;
                         // add listeners.
-                        attrs.$observe("ngDrop", onEnableChange);
+                        scope.$watch(attrs.ngDrop, onEnableChange);
                         scope.$on('$destroy', onDestroy);
                         scope.$on('draggable:start', onDragStart);
                         scope.$on('draggable:move', onDragMove);
@@ -267,7 +267,7 @@ angular.module("ngDraggable", [])
                         toggleListeners(false);
                     };
                     var onEnableChange = function (newVal, oldVal) {
-                        _dropEnabled=scope.$eval(newVal);
+                        _dropEnabled=newVal;
                     };
                     var onDragStart = function(evt, obj) {
                         if(! _dropEnabled)return;


### PR DESCRIPTION
Resolves #115.

At the moment `attrs.$observe` is used for `ng-drop` and `scope.$watch` for `ng-drag`. This has the effect that when using dynamic values for those attributes, they have to be specified inconsitently as `ng-drag="booleanVariable"` and `ng-drop="{{booleanVariable}}"`.

This patch adjusts the behaviour of `ng-drop` to match `ng-drag`.