### PR TITLE
Add ng-drag-enter and ng-drag-leave attributes and events

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -232,7 +232,7 @@ angular.module("ngDraggable", [])
             };
         }])
 
-        .directive('ngDrop', ['$parse', '$timeout', '$window', '$document', 'ngDraggable', function ($parse, $timeout, $window, $document, ngDraggable) {
+        .directive('ngDrop', ['$parse', '$timeout', '$window', '$document', 'ngDraggable', '$rootScope', function ($parse, $timeout, $window, $document, ngDraggable, $rootScope) {
             return {
                 restrict: 'A',
                 link: function (scope, element, attrs) {
@@ -250,6 +250,8 @@ angular.module("ngDraggable", [])
                     var onDragStartCallback = $parse(attrs.ngDragStart);
                     var onDragStopCallback = $parse(attrs.ngDragStop);
                     var onDragMoveCallback = $parse(attrs.ngDragMove);
+                    var onDragEnterCallback = $parse(attrs.ngDragEnter);
+                    var onDragLeaveCallback = $parse(attrs.ngDragLeave);
 
                     var initialize = function () {
                         toggleListeners(true);
@@ -275,7 +277,7 @@ angular.module("ngDraggable", [])
                     };
                     var onDragStart = function(evt, obj) {
                         if(! _dropEnabled)return;
-                        isTouching(obj.x,obj.y,obj.element);
+                        isTouching(obj.x,obj.y,obj.element,evt,obj);
 
                         if (attrs.ngDragStart) {
                             $timeout(function(){
@@ -285,7 +287,7 @@ angular.module("ngDraggable", [])
                     };
                     var onDragMove = function(evt, obj) {
                         if(! _dropEnabled)return;
-                        isTouching(obj.x,obj.y,obj.element);
+                        isTouching(obj.x,obj.y,obj.element,evt,obj);
 
                         if (attrs.ngDragMove) {
                             $timeout(function(){
@@ -302,7 +304,7 @@ angular.module("ngDraggable", [])
                             updateDragStyles(false, obj.element);
                             return;
                         }
-                        if (isTouching(obj.x, obj.y, obj.element)) {
+                        if (isTouching(obj.x, obj.y, obj.element, evt, obj)) {
                             // call the ngDraggable ngDragSuccess element callback
                            if(obj.callback){
                                 obj.callback(obj);
@@ -324,8 +326,29 @@ angular.module("ngDraggable", [])
                         updateDragStyles(false, obj.element);
                     };
 
-                    var isTouching = function(mouseX, mouseY, dragElement) {
+                    var isTouching = function(mouseX, mouseY, dragElement, evt, obj) {
                         var touching= hitTest(mouseX, mouseY);
+
+                        if (touching && !scope.isTouching) {
+                            $rootScope.$broadcast('draggable:dragEnter', { x: mouseX, y: mouseY, event: evt, element: element, dragElement: dragElement, data: obj.data, uid: _myid });
+
+                            if (attrs.ngDragEnter) {
+                                setTimeout(function() { // Make sure to always run dragEnter after dragLeave when moving from one drop element to another
+                                    $timeout(function() {
+                                        onDragEnterCallback(scope, {$data: obj.data, $event: obj, $target: scope.$eval(scope.value)});
+                                    });
+                                }, 0);
+                            }
+                        } else if (!touching && scope.isTouching) {
+                            $rootScope.$broadcast('draggable:dragLeave', { x: mouseX, y: mouseY, event: evt, element: element, dragElement: dragElement, data: obj.data, uid: _myid });
+
+                            if (attrs.ngDragLeave) {
+                                $timeout(function() {
+                                    onDragLeaveCallback(scope, {$data: obj.data, $event: obj, $target: scope.$eval(scope.value)});
+                                });
+                            }
+                        }
+
                         scope.isTouching = touching;
                         if(touching){
                             _lastDropTouch = element;


### PR DESCRIPTION
This patch adds the `ng-drag-enter` and `ng-drag-leave` attributes to the `ng-drop` directive. They are executed when a dragging element enters and leaves the drop element.

It also adds the events `draggable:dragEnter` and `draggable:dragLeave` events.