### PR TITLE
makes ng-drag-handle work without jQuery

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -45,7 +45,13 @@ angular.module("ngDraggable", [])
                     var initialize = function () {
                         element.attr('draggable', 'false'); // prevent native drag
                         // check to see if drag handle(s) was specified
-                        var dragHandles = element.find('[ng-drag-handle]');
+                        // if querySelectorAll is available, we use this instead of find
+                        // as JQLite find is limited to tagnames
+                        if (element[0].querySelectorAll) {
+                            var dragHandles = angular.element(element[0].querySelectorAll('[ng-drag-handle]'));
+                        } else {
+                            var dragHandles = element.find('[ng-drag-handle]');
+                        }
                         if (dragHandles.length) {
                             _dragHandle = dragHandles;
                         }


### PR DESCRIPTION
Use querySelectorAll if available to make `ng-drag-handle` work without jQuery as jqLite find is limited to tag names (see: https://docs.angularjs.org/api/ng/function/angular.element)