### PR TITLE
Added a check for event.originalEvent.touches in scope.inputEvent

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -8,7 +8,13 @@ angular.module("ngDraggable", [])
 
             var scope = this;
             scope.inputEvent = function(event) {
-                return angular.isDefined(event.touches) ? event.touches[0] : event;
+                if (angular.isDefined(event.touches)) {
+                    return event.touches[0];
+                }
+                else if (angular.isDefined(event.originalEvent.touches)) {
+                    return event.originalEvent.touches[0];
+                }
+                return event;
             };
 
         }])


### PR DESCRIPTION
In the function scope.inputEvent for some reason I cannot pin point yet, when I am working in iPhone emulator within Google Chrome the positions in the event object are undefined.  For example when you attempt to access event.x or event.y it will return a value of undefined which will cause the drag element to be un-droppable.  After adding a check for event.originalEvent I was able to get a touches property that have values for x and y.

One thing to note is that if I turn off the emulator the exact same code will work even without the fix in this pull request.