### PR TITLE
Fix scroll issues on Chrome and flickering on all browsers

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -543,8 +543,8 @@ angular.module("ngDraggable", [])
 
                         if (scrollX !== 0 || scrollY !== 0) {
                             // Record the current scroll position.
-                            var currentScrollLeft = $document[0].documentElement.scrollLeft;
-                            var currentScrollTop = $document[0].documentElement.scrollTop;
+                            var currentScrollLeft = ($window.pageXOffset || $document[0].documentElement.scrollLeft);
+                            var currentScrollTop = ($window.pageYOffset || $document[0].documentElement.scrollTop);
 
                             // Remove the transformation from the element, scroll the window by the scroll distance
                             // record how far we scrolled, then reapply the element transformation.
@@ -553,8 +553,8 @@ angular.module("ngDraggable", [])
 
                             $window.scrollBy(scrollX, scrollY);
 
-                            var horizontalScrollAmount = $document[0].documentElement.scrollLeft - currentScrollLeft;
-                            var verticalScrollAmount =  $document[0].documentElement.scrollTop - currentScrollTop;
+                            var horizontalScrollAmount = ($window.pageXOffset || $document[0].documentElement.scrollLeft) - currentScrollLeft;
+                            var verticalScrollAmount =  ($window.pageYOffset || $document[0].documentElement.scrollTop) - currentScrollTop;
 
                             element.css('transform', elementTransform);
 

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -503,8 +503,7 @@ angular.module("ngDraggable", [])
                     verticalScroll: attrs.verticalScroll || true,
                     horizontalScroll: attrs.horizontalScroll || true,
                     activationDistance: attrs.activationDistance || 75,
-                    scrollDistance: attrs.scrollDistance || 50,
-                    scrollInterval: attrs.scrollInterval || 250
+                    scrollDistance: attrs.scrollDistance || 15
                 };
 
 
@@ -527,10 +526,10 @@ angular.module("ngDraggable", [])
                         var args = Array.prototype.slice.call(arguments);
                         if(animationIsOn) {
                             reqAnimFrame(function () {
-                                $timeout(function () {
-                                    callback.apply(null, args);
-                                    nextFrame(callback);
-                                }, config.scrollInterval);
+                              $rootScope.$apply(function () {
+                                callback.apply(null, args);
+                                nextFrame(callback);
+                              });
                             })
                         }
                     }


### PR DESCRIPTION
**API CHANGE**: Removed `scrollInterval` attribute from `ngDragScroll` directive.

Here I replaced the `$interval` on `ngDragScroll` with the `requestAnimationFrame` function, to release pressure from the browser, maximizing performance. This stops the flickering. To improve performance even more, I removed the `scrollInterval` attribute need. You can change the scroll speed just using the `scrollDistance`, as the `requestAnimationFrame` itself will do the job of set the right time rate.

On Chrome, however, there was another bug. The `$document[0].documentElement.scrollLeft` and `$document[0].documentElement.scrollTop` functions doesn't work with chrome, so I changed the code to use `$window.pageXOffset ` and `$window.pageYOffset`, respectively, with it.

Everything works here. I tested on Chrome 42 (Mac), Firefox 36.0.1 (Mac) and Safari 8.0.6 (Mac). I couldn't test for Internet Explorer, so if anyone can, please do it.

Thanks