### PR TITLE
Fixes scroll offset when allowTransform="false" and dragged element is in position fixed div

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -43,6 +43,10 @@ angular.module("ngDraggable", [])
                     var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
                     var allowTransform = angular.isDefined(attrs.allowTransform) ? scope.$eval(attrs.allowTransform) : true;
 
+		    // Adjust scroll offset if drag element is in a position fixed div and we scroll while dragging
+                    var scrollOffset = angular.isDefined(attrs.scrollOffset) ? scope.$eval(attrs.scrollOffset) : false;
+                    scrollOffset = scrollOffset && !allowTransform;
+
                     var getDragData = $parse(attrs.ngDragData);
 
                     // deregistration function for mouse move events in $rootScope triggered by jqLite trigger handler
@@ -141,7 +145,7 @@ angular.module("ngDraggable", [])
 
                         offset = element[0].getBoundingClientRect();
                         if(allowTransform)
-                        _dragOffset = offset;
+                            _dragOffset = offset;
                         else{
                             _dragOffset = {left:document.body.scrollLeft, top:document.body.scrollTop};
                         }
@@ -192,6 +196,15 @@ angular.module("ngDraggable", [])
                         } else {
                             _tx = _mx - _mrx - _dragOffset.left;
                             _ty = _my - _mry - _dragOffset.top;
+                        }
+
+			// Adjust offset based on scroll
+                        if (scrollOffset) {
+                            if (_dragOffset.top === 0) {
+                                _ty = _ty - document.body.scrollTop;
+                            } else if (_dragOffset.top > 0) {
+                                _ty = _ty - document.body.scrollTop + (2 * _dragOffset.top);
+                            }
                         }
 
                         moveElement(_tx, _ty);

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -43,7 +43,7 @@ angular.module("ngDraggable", [])
                     var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
                     var allowTransform = angular.isDefined(attrs.allowTransform) ? scope.$eval(attrs.allowTransform) : true;
 
-		    // Adjust scroll offset if drag element is in a position fixed div and we scroll while dragging
+                    // Adjust scroll offset if drag element is in a position fixed div and we scroll while dragging
                     var scrollOffset = angular.isDefined(attrs.scrollOffset) ? scope.$eval(attrs.scrollOffset) : false;
                     scrollOffset = scrollOffset && !allowTransform;
 
@@ -198,7 +198,7 @@ angular.module("ngDraggable", [])
                             _ty = _my - _mry - _dragOffset.top;
                         }
 
-			// Adjust offset based on scroll
+                        // Adjust offset based on scroll
                         if (scrollOffset) {
                             if (_dragOffset.top === 0) {
                                 _ty = _ty - document.body.scrollTop;

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -147,7 +147,7 @@ angular.module("ngDraggable", [])
                         if(allowTransform)
                             _dragOffset = offset;
                         else{
-                            _dragOffset = {left:document.body.scrollLeft, top:document.body.scrollTop};
+                            _dragOffset = {left:document.body.scrollLeft, top: ($window.pageYOffset || document.body.scrollTop)};
                         }
 
 
@@ -201,9 +201,9 @@ angular.module("ngDraggable", [])
                         // Adjust offset based on scroll
                         if (scrollOffset) {
                             if (_dragOffset.top === 0) {
-                                _ty = _ty - document.body.scrollTop;
+                                _ty = _ty - ($window.pageYOffset || document.body.scrollTop);
                             } else if (_dragOffset.top > 0) {
-                                _ty = _ty - document.body.scrollTop + (2 * _dragOffset.top);
+                                _ty = _ty - ($window.pageYOffset || document.body.scrollTop) + (2 * _dragOffset.top);
                             }
                         }
 


### PR DESCRIPTION
Hi,

This code has fixed for me the wrong offset on the dragged element when scrolling. I met this problem while I had disabled allowTransform and while the dragged element was inside a position fixed div with fixed height and width.

To use it : 

``` html
<div class="col-lg-6 draggable-media" ng-drag="true" ng-drag-data="media" data-allow-transform="false" data-scroll-offset="true">
    Dragged HTML
</div>
```

It should fix at least : 

* #142 : my (or my team) previous issue
* #157 : Maybe. But he does not seem to use allowTransform="false" and my fixes has only be tested with this configuration (https://github.com/fatlinesofcode/ngDraggable/compare/master...bein-sports:feat-scroll-offset?expand=1#diff-045be7ab7709e1d9df374e76bac2659cR48)
* #158 : Same as #157 

Regards