### PR TITLE
Use css position:fixed as dragging method

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -42,7 +42,6 @@ angular.module("ngDraggable", [])
                     var _pressTimer = null;
 
                     var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
-                    var allowTransform = angular.isDefined(attrs.allowTransform) ? scope.$eval(attrs.allowTransform) : true;
 
                     var getDragData = $parse(attrs.ngDragData);
 
@@ -98,7 +97,7 @@ angular.module("ngDraggable", [])
                     var isClickableElement = function (evt) {
                         return (
                                 angular.isDefined(angular.element(evt.target).attr("ng-cancel-drag"))
-                                );
+                        );
                     };
                     /*
                      * When the element is clicked start the drag behaviour
@@ -141,11 +140,7 @@ angular.module("ngDraggable", [])
                         evt.preventDefault();
 
                         offset = element[0].getBoundingClientRect();
-                        if(allowTransform)
-                        _dragOffset = offset;
-                        else{
-                            _dragOffset = {left:document.body.scrollLeft, top:document.body.scrollTop};
-                        }
+                        _dragOffset = {left:document.body.scrollLeft, top:document.body.scrollTop};
 
 
                         element.centerX = element[0].offsetWidth / 2;
@@ -222,23 +217,11 @@ angular.module("ngDraggable", [])
                     };
 
                     var reset = function() {
-                        if(allowTransform)
-                        element.css({transform:'', 'z-index':'', '-webkit-transform':'', '-ms-transform':''});
-                        else
                         element.css({'position':'',top:'',left:''});
                     };
 
                     var moveElement = function (x, y) {
-                        if(allowTransform) {
-                            element.css({
-                                transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
-                                'z-index': 99999,
-                                '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
-                                '-ms-transform': 'matrix(1, 0, 0, 1, ' + x + ', ' + y + ')'
-                            });
-                        }else{
-                            element.css({'left':x+'px','top':y+'px', 'position':'fixed'});
-                        }
+                        element.css({'left':x+'px','top':y+'px', 'position':'fixed'});
                     };
                     initialize();
                 }
@@ -426,8 +409,8 @@ angular.module("ngDraggable", [])
                     var onDragMove = function(evt, obj) {
                         if(_allowClone) {
 
-                            _tx = obj.tx + _dragOffset.left;
-                            _ty = obj.ty + _dragOffset.top;
+                            _tx = _dragOffset.left;
+                            _ty = _dragOffset.top;
 
                             moveElement(_tx, _ty);
                         }


### PR DESCRIPTION
Currently if drag from a div with overflow:hidden or scroll or auto, the element to be dragged will be trapped inside the div. Using position:fixed for all dragging action will solves the problem.

Not 100% sure if there will be any drawbacks, but at least the examples works and it works fine when I am using the code in my own project.