### PR TITLE
ng-cancel-drag now works with dynamic child elements

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -501,6 +501,14 @@ angular.module("ngDraggable", [])
             restrict: 'A',
             link: function (scope, element, attrs) {
                 element.find('*').attr('ng-cancel-drag', 'ng-cancel-drag');
+
+                // for the case the content of ng-cancel-drag is dynamic...
+                scope.$watch(function () {
+                        return element[0].childNodes.length;
+                    },
+                    function (oldValue, newValue) {
+                        element.find('*:not([ng-cancel-drag])').attr('ng-cancel-drag', 'ng-cancel-drag');
+                    });
             }
         };
     }])


### PR DESCRIPTION
I have a tree like ngDrag > select >  option and the options are generated with ng-option, so there is no ways to set the ng-cancel-drag for the options. 
If the options have no ng-cancel-drag firefox is buggy when clicking on a option. 