### PR TITLE
Made drag delay configurable by attribute

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -40,6 +40,7 @@ angular.module("ngDraggable", [])
                 var _dragEnabled = false;
 
                 var _pressTimer = null;
+                var pressTimeout = attrs.pressTimeout || 100;
 
                 var onDragStartCallback = $parse(attrs.ngDragStart) || null;
                 var onDragStopCallback = $parse(attrs.ngDragStop) || null;
@@ -123,7 +124,7 @@ angular.module("ngDraggable", [])
                         _pressTimer = setTimeout(function(){
                             cancelPress();
                             onlongpress(evt);
-                        },100);
+                        }, pressTimeout);
                         $document.on(_moveEvents, cancelPress);
                         $document.on(_releaseEvents, cancelPress);
                     }else{


### PR DESCRIPTION
This PR fix #163 issue.
Usage example:

``` html
<ul class="draggable-objects">
  <li  ng-repeat="obj in draggableObjects" >
   <div ng-drag="true" ng-drag-data="obj" press-timeout="10" data-allow-transform="true"> {{obj.name}} </div>
 </li>
</ul>
```

I have better results using  `10` milliseconds timeout. If press-timeout attribute is not defined, `100` will be used as default.
