### PR TITLE
assert that ngCancelDrag's postLink is executed after other directives with default priority

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -516,6 +516,7 @@ angular.module("ngDraggable", [])
     .directive('ngCancelDrag', [function () {
         return {
             restrict: 'A',
+            priority: 1,
             link: function (scope, element, attrs) {
                 element.find('*').attr('ng-cancel-drag', 'ng-cancel-drag');
             }

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -122,7 +122,6 @@ angular.module('ngDraggable', [])
                  * On touch devices as a small delay so as not to prevent native window scrolling
                  */
                 var onpress = function (evt) {
-                    // console.log("110"+" onpress: "+Math.random()+" "+ evt.type);
                     if (!_dragEnabled) return;
 
                     if (isClickableElement(evt)) {
@@ -134,7 +133,7 @@ angular.module('ngDraggable', [])
                         return;
                     }
 
-                    var useTouch = evt.type === 'touchstart' ? true : false;
+                    var useTouch = evt.type === 'touchstart';
 
 
                     if (useTouch) {
@@ -296,7 +295,7 @@ angular.module('ngDraggable', [])
                     if (allowTransform)
                         element.css({ transform: '', 'z-index': '', '-webkit-transform': '', '-ms-transform': '' });
                     else
-                        element.css({ 'position': '', top: '', left: '' });
+                        element.css({ position: '', top: '', left: '', 'z-index': '' });
                 };
 
                 var moveElement = function (x, y) {
@@ -312,7 +311,7 @@ angular.module('ngDraggable', [])
                             'left': x + 'px',
                             'top': y + 'px',
                             'position': 'fixed',
-                            'z-index': '99999'
+                            'z-index': 99999
                         });
                     }
                 };

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -2,12 +2,12 @@
  *
  * https://github.com/fatlinesofcode/ngDraggable
  */
-angular.module("ngDraggable", [])
-    .service('ngDraggable', [function() {
+angular.module('ngDraggable', [])
+    .service('ngDraggable', [function () {
 
 
         var scope = this;
-        scope.inputEvent = function(event) {
+        scope.inputEvent = function (event) {
             if (angular.isDefined(event.touches)) {
                 return event.touches[0];
             }
@@ -26,7 +26,7 @@ angular.module("ngDraggable", [])
             restrict: 'A',
             link: function (scope, element, attrs) {
                 scope.value = attrs.ngDrag;
-                var offset,_centerAnchor=false,_mx,_my,_tx,_ty,_mrx,_mry;
+                var offset, _centerAnchor = false, _mx, _my, _tx, _ty, _mrx, _mry;
                 var _hasTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
                 var _pressEvents = 'touchstart mousedown';
                 var _moveEvents = 'touchmove mousemove';
@@ -46,7 +46,13 @@ angular.module("ngDraggable", [])
                 // tracks amount of scrollContainer is scrolled from drag start
                 var _scrolled = 0;
 
-                var scrollContainer = angular.isDefined(attrs.ngDragScrollContainer) ? angular.element(attrs.ngDragScrollContainer)[0] : null;
+                var scrollContainer = null;
+
+                scope.$watch(attrs.ngDragScrollContainer, function (newValue) {
+                    if (newValue) {
+                        scrollContainer = newValue[0];
+                    }
+                });
                 var onDragStartCallback = $parse(attrs.ngDragStart) || null;
                 var onDragStopCallback = $parse(attrs.ngDragStop) || null;
                 var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
@@ -74,7 +80,7 @@ angular.module("ngDraggable", [])
                 };
 
                 var toggleListeners = function (enable) {
-                    if (!enable)return;
+                    if (!enable) return;
                     // add listeners.
 
                     scope.$on('$destroy', onDestroy);
@@ -89,8 +95,10 @@ angular.module("ngDraggable", [])
                         element.on(_pressEvents, onpress);
                     }
                     // if(! _hasTouch && element[0].nodeName.toLowerCase() == "img"){
-                    if( element[0].nodeName.toLowerCase() == "img"){
-                        element.on('mousedown', function(){ return false;}); // prevent native drag for images
+                    if (element[0].nodeName.toLowerCase() == 'img') {
+                        element.on('mousedown', function () {
+                            return false;
+                        }); // prevent native drag for images
                     }
                 };
                 var onDestroy = function (enable) {
@@ -100,28 +108,28 @@ angular.module("ngDraggable", [])
                     _dragEnabled = (newVal);
                 };
                 var onCenterAnchor = function (newVal, oldVal) {
-                    if(angular.isDefined(newVal))
+                    if (angular.isDefined(newVal))
                         _centerAnchor = (newVal || 'true');
                 };
 
                 var isClickableElement = function (evt) {
                     return (
-                        angular.isDefined(angular.element(evt.target).attr("ng-cancel-drag"))
+                        angular.isDefined(angular.element(evt.target).attr('ng-cancel-drag'))
                     );
                 };
                 /*
                  * When the element is clicked start the drag behaviour
                  * On touch devices as a small delay so as not to prevent native window scrolling
                  */
-                var onpress = function(evt) {
+                var onpress = function (evt) {
                     // console.log("110"+" onpress: "+Math.random()+" "+ evt.type);
-                    if(! _dragEnabled)return;
+                    if (!_dragEnabled) return;
 
                     if (isClickableElement(evt)) {
                         return;
                     }
 
-                    if (evt.type == "mousedown" && evt.button != 0) {
+                    if (evt.type == 'mousedown' && evt.button != 0) {
                         // Do not start dragging on right-click
                         return;
                     }
@@ -129,36 +137,36 @@ angular.module("ngDraggable", [])
                     var useTouch = evt.type === 'touchstart' ? true : false;
 
 
-                    if(useTouch){
+                    if (useTouch) {
                         cancelPress();
-                        _pressTimer = setTimeout(function(){
+                        _pressTimer = setTimeout(function () {
                             cancelPress();
                             onlongpress(evt);
                             onmove(evt);
-                        },ngDraggable.touchTimeout);
+                        }, ngDraggable.touchTimeout);
                         $document.on(_moveEvents, cancelPress);
                         $document.on(_releaseEvents, cancelPress);
-                    }else{
+                    } else {
                         onlongpress(evt);
                     }
 
                 };
 
-                var cancelPress = function() {
+                var cancelPress = function () {
                     clearTimeout(_pressTimer);
                     $document.off(_moveEvents, cancelPress);
                     $document.off(_releaseEvents, cancelPress);
                 };
 
-                var onlongpress = function(evt) {
-                    if(! _dragEnabled)return;
+                var onlongpress = function (evt) {
+                    if (!_dragEnabled) return;
                     evt.preventDefault();
 
                     offset = element[0].getBoundingClientRect();
-                    if(allowTransform)
+                    if (allowTransform)
                         _dragOffset = offset;
-                    else{
-                        _dragOffset = {left:document.body.scrollLeft, top:document.body.scrollTop};
+                    else {
+                        _dragOffset = { left: document.body.scrollLeft, top: document.body.scrollTop };
                     }
 
 
@@ -183,13 +191,13 @@ angular.module("ngDraggable", [])
                     // jqLite unfortunately only supports triggerHandler(...)
                     // See http://api.jquery.com/triggerHandler/
                     // _deregisterRootMoveListener = $rootScope.$on('draggable:_triggerHandlerMove', onmove);
-                    _deregisterRootMoveListener = $rootScope.$on('draggable:_triggerHandlerMove', function(event, origEvent) {
+                    _deregisterRootMoveListener = $rootScope.$on('draggable:_triggerHandlerMove', function (event, origEvent) {
                         onmove(origEvent);
                     });
                 };
 
                 var onmove = function (evt) {
-                    if (!_dragEnabled)return;
+                    if (!_dragEnabled) return;
                     evt.preventDefault();
 
                     if (!element.hasClass('dragging')) {
@@ -198,10 +206,18 @@ angular.module("ngDraggable", [])
                         if (scrollContainer) {
                             _scrolled = scrollContainer.scrollTop;
                         }
-                        $rootScope.$broadcast('draggable:start', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data});
-                        if (onDragStartCallback ){
+                        $rootScope.$broadcast('draggable:start', {
+                            x: _mx,
+                            y: _my,
+                            tx: _tx,
+                            ty: _ty,
+                            event: evt,
+                            element: element,
+                            data: _data
+                        });
+                        if (onDragStartCallback) {
                             scope.$apply(function () {
-                                onDragStartCallback(scope, {$data: _data, $event: evt});
+                                onDragStartCallback(scope, { $data: _data, $event: evt });
                             });
                         }
                     }
@@ -223,55 +239,75 @@ angular.module("ngDraggable", [])
 
                     moveElement(_tx, _ty);
 
-                    $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid, dragOffset: _dragOffset });
+                    $rootScope.$broadcast('draggable:move', {
+                        x: _mx,
+                        y: _my,
+                        tx: _tx,
+                        ty: _ty,
+                        event: evt,
+                        element: element,
+                        data: _data,
+                        uid: _myid,
+                        dragOffset: _dragOffset
+                    });
                 };
 
-                var onrelease = function(evt) {
+                var onrelease = function (evt) {
                     if (!_dragEnabled)
                         return;
                     evt.preventDefault();
-                    $rootScope.$broadcast('draggable:end', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data, callback:onDragComplete, uid: _myid});
+                    $rootScope.$broadcast('draggable:end', {
+                        x: _mx,
+                        y: _my,
+                        tx: _tx,
+                        ty: _ty,
+                        event: evt,
+                        element: element,
+                        data: _data,
+                        callback: onDragComplete,
+                        uid: _myid
+                    });
                     element.removeClass('dragging');
                     element.parent().find('.drag-enter').removeClass('drag-enter');
                     reset();
                     $document.off(_moveEvents, onmove);
                     $document.off(_releaseEvents, onrelease);
 
-                    if (onDragStopCallback ){
+                    if (onDragStopCallback) {
                         scope.$apply(function () {
-                            onDragStopCallback(scope, {$data: _data, $event: evt});
+                            onDragStopCallback(scope, { $data: _data, $event: evt });
                         });
                     }
 
                     _deregisterRootMoveListener();
                 };
 
-                var onDragComplete = function(evt) {
+                var onDragComplete = function (evt) {
 
 
-                    if (!onDragSuccessCallback )return;
+                    if (!onDragSuccessCallback) return;
 
                     scope.$apply(function () {
-                        onDragSuccessCallback(scope, {$data: _data, $event: evt});
+                        onDragSuccessCallback(scope, { $data: _data, $event: evt });
                     });
                 };
 
-                var reset = function() {
-                    if(allowTransform)
-                        element.css({transform:'', 'z-index':'', '-webkit-transform':'', '-ms-transform':''});
+                var reset = function () {
+                    if (allowTransform)
+                        element.css({ transform: '', 'z-index': '', '-webkit-transform': '', '-ms-transform': '' });
                     else
-                        element.css({'position':'',top:'',left:''});
+                        element.css({ 'position': '', top: '', left: '' });
                 };
 
                 var moveElement = function (x, y) {
-                    if(allowTransform) {
+                    if (allowTransform) {
                         element.css({
                             transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
                             'z-index': 99999,
                             '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
                             '-ms-transform': 'matrix(1, 0, 0, 1, ' + x + ', ' + y + ')'
                         });
-                    }else{
+                    } else {
                         element.css({
                             'left': x + 'px',
                             'top': y + 'px',
@@ -292,11 +328,11 @@ angular.module("ngDraggable", [])
                 scope.value = attrs.ngDrop;
                 scope.isTouching = false;
 
-                var _lastDropTouch=null;
+                var _lastDropTouch = null;
 
                 var _myid = scope.$id;
 
-                var _dropEnabled=false;
+                var _dropEnabled = false;
 
                 var onDropCallback = $parse(attrs.ngDropSuccess);// || function(){};
 
@@ -311,7 +347,7 @@ angular.module("ngDraggable", [])
                 var toggleListeners = function (enable) {
                     // remove listeners
 
-                    if (!enable)return;
+                    if (!enable) return;
                     // add listeners.
                     scope.$watch(attrs.ngDrop, onEnableChange);
                     scope.$on('$destroy', onDestroy);
@@ -324,25 +360,25 @@ angular.module("ngDraggable", [])
                     toggleListeners(false);
                 };
                 var onEnableChange = function (newVal, oldVal) {
-                    _dropEnabled=newVal;
+                    _dropEnabled = newVal;
                 };
-                var onDragStart = function(evt, obj) {
-                    if(! _dropEnabled)return;
-                    isTouching(obj.x,obj.y,obj.element);
+                var onDragStart = function (evt, obj) {
+                    if (!_dropEnabled) return;
+                    isTouching(obj.x, obj.y, obj.element);
 
                     if (attrs.ngDragStart) {
-                        $timeout(function(){
-                            onDragStartCallback(scope, {$data: obj.data, $event: obj});
+                        $timeout(function () {
+                            onDragStartCallback(scope, { $data: obj.data, $event: obj });
                         });
                     }
                 };
-                var onDragMove = function(evt, obj) {
-                    if(! _dropEnabled)return;
-                    isTouching(obj.x,obj.y,obj.element);
+                var onDragMove = function (evt, obj) {
+                    if (!_dropEnabled) return;
+                    isTouching(obj.x, obj.y, obj.element);
 
                     if (attrs.ngDragMove) {
-                        $timeout(function(){
-                            onDragMoveCallback(scope, {$data: obj.data, $event: obj});
+                        $timeout(function () {
+                            onDragMoveCallback(scope, { $data: obj.data, $event: obj });
                         });
                     }
                 };
@@ -357,52 +393,56 @@ angular.module("ngDraggable", [])
                     }
                     if (isTouching(obj.x, obj.y, obj.element)) {
                         // call the ngDraggable ngDragSuccess element callback
-                        if(obj.callback){
+                        if (obj.callback) {
                             obj.callback(obj);
                         }
 
                         if (attrs.ngDropSuccess) {
-                            $timeout(function(){
-                                onDropCallback(scope, {$data: obj.data, $event: obj, $target: scope.$eval(scope.value)});
+                            $timeout(function () {
+                                onDropCallback(scope, {
+                                    $data: obj.data,
+                                    $event: obj,
+                                    $target: scope.$eval(scope.value)
+                                });
                             });
                         }
                     }
 
                     if (attrs.ngDragStop) {
-                        $timeout(function(){
-                            onDragStopCallback(scope, {$data: obj.data, $event: obj});
+                        $timeout(function () {
+                            onDragStopCallback(scope, { $data: obj.data, $event: obj });
                         });
                     }
 
                     updateDragStyles(false, obj.element);
                 };
 
-                var isTouching = function(mouseX, mouseY, dragElement) {
-                    var touching= hitTest(mouseX, mouseY);
+                var isTouching = function (mouseX, mouseY, dragElement) {
+                    var touching = hitTest(mouseX, mouseY);
                     scope.isTouching = touching;
-                    if(touching){
+                    if (touching) {
                         _lastDropTouch = element;
                     }
                     updateDragStyles(touching, dragElement);
                     return touching;
                 };
 
-                var updateDragStyles = function(touching, dragElement) {
-                    if(touching){
+                var updateDragStyles = function (touching, dragElement) {
+                    if (touching) {
                         element.addClass('drag-enter');
                         dragElement.addClass('drag-over');
-                    }else if(_lastDropTouch == element){
-                        _lastDropTouch=null;
+                    } else if (_lastDropTouch == element) {
+                        _lastDropTouch = null;
                         element.removeClass('drag-enter');
                         dragElement.removeClass('drag-over');
                     }
                 };
 
-                var hitTest = function(x, y) {
+                var hitTest = function (x, y) {
                     var bounds = element[0].getBoundingClientRect();// ngDraggable.getPrivOffset(element);
                     x -= $document[0].body.scrollLeft + $document[0].documentElement.scrollLeft;
                     y -= $document[0].body.scrollTop + $document[0].documentElement.scrollTop;
-                    return  x >= bounds.left
+                    return x >= bounds.left
                         && x <= bounds.right
                         && y <= bounds.bottom
                         && y >= bounds.top;
@@ -416,7 +456,7 @@ angular.module("ngDraggable", [])
         return {
             restrict: 'A',
             link: function (scope, element, attrs) {
-                var img, _allowClone=true;
+                var img, _allowClone = true;
                 var _dragOffset = null;
                 scope.clonedData = {};
                 var initialize = function () {
@@ -432,7 +472,7 @@ angular.module("ngDraggable", [])
                 var toggleListeners = function (enable) {
                     // remove listeners
 
-                    if (!enable)return;
+                    if (!enable) return;
                     // add listeners.
                     scope.$on('draggable:start', onDragStart);
                     scope.$on('draggable:move', onDragMove);
@@ -440,18 +480,18 @@ angular.module("ngDraggable", [])
                     preventContextMenu();
 
                 };
-                var preventContextMenu = function() {
+                var preventContextMenu = function () {
                     //  element.off('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                     img.off('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                     //  element.on('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                     img.on('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                 };
-                var onDragStart = function(evt, obj, elm) {
-                    _allowClone=true;
-                    if(angular.isDefined(obj.data.allowClone)){
-                        _allowClone=obj.data.allowClone;
+                var onDragStart = function (evt, obj, elm) {
+                    _allowClone = true;
+                    if (angular.isDefined(obj.data.allowClone)) {
+                        _allowClone = obj.data.allowClone;
                     }
-                    if(_allowClone) {
+                    if (_allowClone) {
                         scope.$apply(function () {
                             scope.clonedData = obj.data;
                         });
@@ -462,8 +502,8 @@ angular.module("ngDraggable", [])
                     }
 
                 };
-                var onDragMove = function(evt, obj) {
-                    if(_allowClone) {
+                var onDragMove = function (evt, obj) {
+                    if (_allowClone) {
 
                         _tx = obj.tx + obj.dragOffset.left;
                         _ty = obj.ty + obj.dragOffset.top;
@@ -471,21 +511,23 @@ angular.module("ngDraggable", [])
                         moveElement(_tx, _ty);
                     }
                 };
-                var onDragEnd = function(evt, obj) {
+                var onDragEnd = function (evt, obj) {
                     //moveElement(obj.tx,obj.ty);
-                    if(_allowClone) {
+                    if (_allowClone) {
                         reset();
                     }
                 };
 
-                var reset = function() {
-                    element.css({left:0,top:0, position:'fixed', 'z-index':-1, visibility:'hidden'});
+                var reset = function () {
+                    element.css({ left: 0, top: 0, position: 'fixed', 'z-index': -1, visibility: 'hidden' });
                 };
-                var moveElement = function(x,y) {
+                var moveElement = function (x, y) {
                     element.css({
-                        transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)', 'z-index': 99999, 'visibility': 'visible',
-                        '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, '+x+', '+y+', 0, 1)',
-                        '-ms-transform': 'matrix(1, 0, 0, 1, '+x+', '+y+')'
+                        transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
+                        'z-index': 99999,
+                        'visibility': 'visible',
+                        '-webkit-transform': 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
+                        '-ms-transform': 'matrix(1, 0, 0, 1, ' + x + ', ' + y + ')'
                         //,margin: '0'  don't monkey with the margin,
                     });
                 };
@@ -517,7 +559,7 @@ angular.module("ngDraggable", [])
                 var toggleListeners = function (enable) {
                     // remove listeners
 
-                    if (!enable)return;
+                    if (!enable) return;
                     // add listeners.
                     element.on('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                 };
@@ -545,14 +587,20 @@ angular.module("ngDraggable", [])
             }
         };
     }])
-    .directive('ngDragScroll', ['$window', '$interval', '$timeout', '$document', '$rootScope', function($window, $interval, $timeout, $document, $rootScope) {
+    .directive('ngDragScroll', ['$window', '$parse', '$interval', '$timeout', '$document', '$rootScope', function ($window, $parse, $interval, $timeout, $document, $rootScope) {
         return {
             restrict: 'A',
-            link: function(scope, element, attrs) {
+            link: function (scope, element, attrs) {
                 var intervalPromise = null;
                 var lastMouseEvent = null;
 
-                var scrollContainer = angular.isDefined(attrs.ngDragScrollContainer) ? angular.element(attrs.ngDragScrollContainer)[0] : null;
+                var scrollContainer = null;
+
+                scope.$watch(attrs.ngDragScrollContainer, function (newValue, oldValue) {
+                    if (newValue) {
+                        scrollContainer = newValue[0];
+                    }
+                });
                 var config = {
                     verticalScroll: attrs.verticalScroll || true,
                     horizontalScroll: attrs.horizontalScroll || true,
@@ -560,34 +608,34 @@ angular.module("ngDraggable", [])
                     scrollDistance: attrs.scrollDistance || 25
                 };
 
-                var reqAnimFrame = (function() {
+                var reqAnimFrame = (function () {
                     return window.requestAnimationFrame ||
                         window.webkitRequestAnimationFrame ||
                         window.mozRequestAnimationFrame ||
                         window.oRequestAnimationFrame ||
                         window.msRequestAnimationFrame ||
-                        function( /* function FrameRequestCallback */ callback, /* DOMElement Element */ element ) {
+                        function (/* function FrameRequestCallback */ callback, /* DOMElement Element */ element) {
                             window.setTimeout(callback, 1000 / 60);
                         };
                 })();
 
                 var animationIsOn = false;
-                var createInterval = function() {
+                var createInterval = function () {
                     animationIsOn = true;
 
                     function nextFrame(callback) {
                         var args = Array.prototype.slice.call(arguments);
-                        if(animationIsOn) {
+                        if (animationIsOn) {
                             reqAnimFrame(function () {
                                 $rootScope.$apply(function () {
                                     callback.apply(null, args);
                                     nextFrame(callback);
                                 });
-                            })
+                            });
                         }
                     }
 
-                    nextFrame(function() {
+                    nextFrame(function () {
                         if (!lastMouseEvent) return;
 
                         var viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
@@ -666,25 +714,25 @@ angular.module("ngDraggable", [])
                     });
                 };
 
-                var clearInterval = function() {
+                var clearInterval = function () {
                     animationIsOn = false;
                 };
 
-                scope.$on('draggable:start', function(event, obj) {
+                scope.$on('draggable:start', function (event, obj) {
                     // Ignore this event if it's not for this element.
                     if (obj.element[0] !== element[0]) return;
 
                     if (!animationIsOn) createInterval();
                 });
 
-                scope.$on('draggable:end', function(event, obj) {
+                scope.$on('draggable:end', function (event, obj) {
                     // Ignore this event if it's not for this element.
                     if (obj.element[0] !== element[0]) return;
 
                     if (animationIsOn) clearInterval();
                 });
 
-                scope.$on('draggable:move', function(event, obj) {
+                scope.$on('draggable:move', function (event, obj) {
                     // Ignore this event if it's not for this element.
                     if (obj.element[0] !== element[0]) return;
 

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -3,6 +3,69 @@
  * https://github.com/fatlinesofcode/ngDraggable
  */
 angular.module("ngDraggable", [])
+    .factory("ngDragHitTest", ['$document', '$window', function($document, $window){
+
+
+        var sidesHitTests = {
+            "top" : function(bounds, mouseX, mouseY, distance)
+            {
+                return  mouseY < bounds.top + distance;
+            },
+            "bottom" : function(bounds, mouseX, mouseY, distance)
+            {
+                return mouseY > bounds.bottom - distance;
+            },
+            "left" : function(bounds, mouseX, mouseY, distance)
+            {
+                return mouseX < bounds.left + distance;
+            },
+            "right" : function(bounds, mouseX, mouseY, distance)
+            {
+                return mouseX > bounds.right - distance;
+            }
+        };
+
+        var pointBoxCollision = function(bounds, mouseX, mouseY)
+        {
+            return  mouseX >= bounds.left
+                && mouseX <= bounds.right
+                && mouseY <= bounds.bottom
+                && mouseY >= bounds.top;
+        }
+
+        var hitTest = function(element, mouseX, mouseY, sides) {
+            var distance = distance || 0;
+            if(sides && sides.hasOwnProperty("all") && sides["all"] !== null)
+            {
+                var distance = sides.all.distance || 10;
+                sides = {
+                    "left"    : {"distance" : distance},
+                    "right"   : {"distance" : distance},
+                    "bottom"  : {"distance" : distance},
+                    "top"     : {"distance" : distance}
+                };
+            }
+
+            var bounds = element.getBoundingClientRect();// ngDraggable.getPrivOffset(element);
+            mouseX -= $document[0].body.scrollLeft + $document[0].documentElement.scrollLeft;
+            mouseY -= $document[0].body.scrollTop + $document[0].documentElement.scrollTop;
+
+            var isInside = pointBoxCollision(bounds, mouseX, mouseY);
+            var result = {"inside" : false};
+            if(isInside)
+            {
+                result.inside = true;
+                for(var side_key in sides)
+                {
+                    var distance = sides[side_key].distance || 10;
+                    result[side_key] = sidesHitTests[side_key](bounds, mouseX, mouseY, distance);
+                }
+                return result;
+            }
+            return result;
+        };
+        return hitTest;
+    }])
     .service('ngDraggable', [function() {
 
 
@@ -18,10 +81,8 @@ angular.module("ngDraggable", [])
             return event;
         };
 
-        scope.touchTimeout = 100;
-
     }])
-    .directive('ngDrag', ['$rootScope', '$parse', '$document', '$window', 'ngDraggable', function ($rootScope, $parse, $document, $window, ngDraggable) {
+    .directive('ngDrag', ['$rootScope', '$parse', '$document', '$window', 'ngDraggable', 'ngDragHitTest', function ($rootScope, $parse, $document, $window, ngDraggable, ngDragHitTest) {
         return {
             restrict: 'A',
             link: function (scope, element, attrs) {
@@ -43,16 +104,21 @@ angular.module("ngDraggable", [])
 
                 var _pressTimer = null;
 
-                // identifies if scrollContainer is scrolled
-                var _scrolled = false;
-
-                var scrollContainer = angular.isDefined(attrs.ngDragScrollContainer) ? angular.element(attrs.ngDragScrollContainer)[0] : null;
                 var onDragStartCallback = $parse(attrs.ngDragStart) || null;
                 var onDragStopCallback = $parse(attrs.ngDragStop) || null;
                 var onDragSuccessCallback = $parse(attrs.ngDragSuccess) || null;
                 var allowTransform = angular.isDefined(attrs.allowTransform) ? scope.$eval(attrs.allowTransform) : true;
+                var doFollowMouse = (attrs.ngDragFollow === "false" || attrs.ngDragFollow === false)? false : true;
+
 
                 var getDragData = $parse(attrs.ngDragData);
+                var dragCloneData = {
+                    group : attrs.ngDragCloneGroup || null,
+                    copyHtml : (attrs.ngDragDCloneCopyHtml === "false" || attrs.ngDragDCloneCopyHtml === false)? false : true,
+                    copyClass : (attrs.ngDragCloneCopyClass === "false" || attrs.ngDragCloneCopyClass === false)? false : true,
+                    addClass : attrs.ngDragCloneAddClass || null,
+                    hideOnClone : (attrs.ngDragCloneHide === "false" || attrs.ngDragCloneHide === false)? false : true
+                };
 
                 // deregistration function for mouse move events in $rootScope triggered by jqLite trigger handler
                 var _deregisterRootMoveListener = angular.noop;
@@ -88,8 +154,7 @@ angular.module("ngDraggable", [])
                         // no handle(s) specified, use the element as the handle
                         element.on(_pressEvents, onpress);
                     }
-                    // if(! _hasTouch && element[0].nodeName.toLowerCase() == "img"){
-                    if( element[0].nodeName.toLowerCase() == "img"){
+                    if(! _hasTouch && element[0].nodeName.toLowerCase() == "img"){
                         element.on('mousedown', function(){ return false;}); // prevent native drag for images
                     }
                 };
@@ -114,7 +179,6 @@ angular.module("ngDraggable", [])
                  * On touch devices as a small delay so as not to prevent native window scrolling
                  */
                 var onpress = function(evt) {
-                    // console.log("110"+" onpress: "+Math.random()+" "+ evt.type);
                     if(! _dragEnabled)return;
 
                     if (isClickableElement(evt)) {
@@ -126,16 +190,12 @@ angular.module("ngDraggable", [])
                         return;
                     }
 
-                    var useTouch = evt.type === 'touchstart' ? true : false;
-
-
-                    if(useTouch){
+                    if(_hasTouch){
                         cancelPress();
                         _pressTimer = setTimeout(function(){
                             cancelPress();
                             onlongpress(evt);
-                            onmove(evt);
-                        },ngDraggable.touchTimeout);
+                        },100);
                         $document.on(_moveEvents, cancelPress);
                         $document.on(_releaseEvents, cancelPress);
                     }else{
@@ -195,10 +255,8 @@ angular.module("ngDraggable", [])
                     if (!element.hasClass('dragging')) {
                         _data = getDragData(scope);
                         element.addClass('dragging');
-                        if (scrollContainer) {
-                            _scrolled = scrollContainer.scrollTop > 0;
-                        }
-                        $rootScope.$broadcast('draggable:start', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data});
+                        $rootScope.$broadcast('draggable:start', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data, dragCloneData : dragCloneData});
+
                         if (onDragStartCallback ){
                             scope.$apply(function () {
                                 onDragStartCallback(scope, {$data: _data, $event: evt});
@@ -217,19 +275,16 @@ angular.module("ngDraggable", [])
                         _ty = _my - _mry - _dragOffset.top;
                     }
 
-                    if (scrollContainer && !_scrolled) {
-                        _ty += scrollContainer.scrollTop;
-                    }
                     moveElement(_tx, _ty);
 
-                    $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid, dragOffset: _dragOffset });
+                    $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid, dragOffset: _dragOffset, dragCloneData : dragCloneData });
                 };
 
                 var onrelease = function(evt) {
                     if (!_dragEnabled)
                         return;
                     evt.preventDefault();
-                    $rootScope.$broadcast('draggable:end', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data, callback:onDragComplete, uid: _myid});
+                    $rootScope.$broadcast('draggable:end', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data, callback:onDragComplete, uid: _myid, dragCloneData : dragCloneData});
                     element.removeClass('dragging');
                     element.parent().find('.drag-enter').removeClass('drag-enter');
                     reset();
@@ -263,6 +318,9 @@ angular.module("ngDraggable", [])
                 };
 
                 var moveElement = function (x, y) {
+                    if(!doFollowMouse)
+                        return;
+
                     if(allowTransform) {
                         element.css({
                             transform: 'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, ' + x + ', ' + y + ', 0, 1)',
@@ -271,12 +329,7 @@ angular.module("ngDraggable", [])
                             '-ms-transform': 'matrix(1, 0, 0, 1, ' + x + ', ' + y + ')'
                         });
                     }else{
-                        element.css({
-                            'left': x + 'px',
-                            'top': y + 'px',
-                            'position': 'fixed',
-                            'z-index': '99999'
-                        });
+                        element.css({'left':x+'px','top':y+'px', 'position':'fixed'});
                     }
                 };
                 initialize();
@@ -284,7 +337,7 @@ angular.module("ngDraggable", [])
         };
     }])
 
-    .directive('ngDrop', ['$parse', '$timeout', '$window', '$document', 'ngDraggable', function ($parse, $timeout, $window, $document, ngDraggable) {
+    .directive('ngDrop', ['$rootScope', '$parse', '$timeout', '$window', '$document', 'ngDraggable', 'ngDragHitTest', function ($rootScope, $parse, $timeout, $window, $document, ngDraggable, ngDragHitTest) {
         return {
             restrict: 'A',
             link: function (scope, element, attrs) {
@@ -302,6 +355,8 @@ angular.module("ngDraggable", [])
                 var onDragStartCallback = $parse(attrs.ngDragStart);
                 var onDragStopCallback = $parse(attrs.ngDragStop);
                 var onDragMoveCallback = $parse(attrs.ngDragMove);
+                var onDragEnterCallback = $parse(attrs.ngDragEnter);
+                var onDragLeaveCallback = $parse(attrs.ngDragLeave);
 
                 var initialize = function () {
                     toggleListeners(true);
@@ -335,16 +390,45 @@ angular.module("ngDraggable", [])
                         });
                     }
                 };
+
                 var onDragMove = function(evt, obj) {
                     if(! _dropEnabled)return;
-                    isTouching(obj.x,obj.y,obj.element);
 
+                    var dragElement = obj.element;
+                    var cbData = {
+                        "drag_data" : obj,
+                        "drop" : element
+                    }
+                    var enterCb = function()
+                    {
+                        $rootScope.$broadcast('droppable:dragenter', {element : element, dragElement : dragElement});
+                        if(attrs.ngDragEnter)
+                        {
+                            scope.$apply(function () {
+                                onDragEnterCallback(scope, {$data : cbData,  $event : obj.event});
+                            });
+                        }
+                    }
+
+                    var leaveCb = function()
+                    {
+                        $rootScope.$broadcast('droppable:dragleave', {element : element, dragElement : dragElement});
+                        if(attrs.ngDragLeave)
+                        {
+                            scope.$apply(function () {
+                                onDragLeaveCallback(scope, {$data : cbData, $event : obj.event});
+                            });
+                        }
+                    }
+
+                    isTouching(obj.x,obj.y,obj.element, enterCb, leaveCb);
                     if (attrs.ngDragMove) {
                         $timeout(function(){
                             onDragMoveCallback(scope, {$data: obj.data, $event: obj});
                         });
                     }
                 };
+
 
                 var onDragEnd = function (evt, obj) {
 
@@ -354,6 +438,7 @@ angular.module("ngDraggable", [])
                         updateDragStyles(false, obj.element);
                         return;
                     }
+
                     if (isTouching(obj.x, obj.y, obj.element)) {
                         // call the ngDraggable ngDragSuccess element callback
                         if(obj.callback){
@@ -376,35 +461,35 @@ angular.module("ngDraggable", [])
                     updateDragStyles(false, obj.element);
                 };
 
-                var isTouching = function(mouseX, mouseY, dragElement) {
+                var isTouching = function(mouseX, mouseY, dragElement, enterCb, leaveCb) {
                     var touching= hitTest(mouseX, mouseY);
                     scope.isTouching = touching;
                     if(touching){
                         _lastDropTouch = element;
                     }
-                    updateDragStyles(touching, dragElement);
+                    updateDragStyles(touching, dragElement, enterCb, leaveCb);
                     return touching;
                 };
 
-                var updateDragStyles = function(touching, dragElement) {
+                var updateDragStyles = function(touching, dragElement, enterCb, leaveCb) {
                     if(touching){
+                        var justEntered = !element.hasClass('drag-enter');
                         element.addClass('drag-enter');
                         dragElement.addClass('drag-over');
+                        if(justEntered && enterCb)
+                            enterCb();
                     }else if(_lastDropTouch == element){
                         _lastDropTouch=null;
+                        var justLeaved = element.hasClass('drag-enter');
                         element.removeClass('drag-enter');
                         dragElement.removeClass('drag-over');
+                        if(justLeaved && leaveCb)
+                            leaveCb();
                     }
                 };
 
-                var hitTest = function(x, y) {
-                    var bounds = element[0].getBoundingClientRect();// ngDraggable.getPrivOffset(element);
-                    x -= $document[0].body.scrollLeft + $document[0].documentElement.scrollLeft;
-                    y -= $document[0].body.scrollTop + $document[0].documentElement.scrollTop;
-                    return  x >= bounds.left
-                        && x <= bounds.right
-                        && y <= bounds.bottom
-                        && y >= bounds.top;
+                var hitTest = function(mouseX, mouseY) {
+                    return ngDragHitTest(element[0], mouseX, mouseY).inside;
                 };
 
                 initialize();
@@ -418,8 +503,28 @@ angular.module("ngDraggable", [])
                 var img, _allowClone=true;
                 var _dragOffset = null;
                 scope.clonedData = {};
-                var initialize = function () {
 
+                var _baseHTML = "";
+                var _baseClass = "";
+                var _group = attrs.ngDragCloneGroup || null;
+                var _copyClass = (attrs.ngDragCloneCopyClass === "false" || attrs.ngDragCloneCopyClass === false)? false : true;
+                var _copyHtml = (attrs.ngDragCloneCopyHtml === "false" || attrs.ngDragDCloneCopyHtml === false)? false : true;
+                var _hideOnClone = (attrs.ngDragCloneHide === "false" || attrs.ngDragDCloneHide === false)? false : true;
+                var _copyHtmlElement = element;
+                if (_copyHtml && attrs.ngDragCloneCopyHtml !== "true" || attrs.ngDragCloneCopyHtml !== true)
+                {
+                    var foundElement = angular.element(element[0].querySelector(".clone_container"));
+                    if (foundElement && foundElement.length > 0)
+                        _copyHtmlElement = foundElement;
+                }
+
+                var _didCopyHtml = false;
+                var _didCopyClass = false;
+                var _didHide = false;
+
+                var initialize = function () {
+                    _baseHTML = _copyHtmlElement.html();
+                    _baseClass = element.attr("class");
                     img = element.find('img');
                     element.attr('draggable', 'false');
                     img.attr('draggable', 'false');
@@ -436,6 +541,8 @@ angular.module("ngDraggable", [])
                     scope.$on('draggable:start', onDragStart);
                     scope.$on('draggable:move', onDragMove);
                     scope.$on('draggable:end', onDragEnd);
+                    scope.$on('droppable:dragenter', onDragEnterDrop);
+                    scope.$on('droppable:dragleave', onDragLeaveDrop);
                     preventContextMenu();
 
                 };
@@ -446,16 +553,40 @@ angular.module("ngDraggable", [])
                     img.on('mousedown touchstart touchmove touchend touchcancel', absorbEvent_);
                 };
                 var onDragStart = function(evt, obj, elm) {
-                    _allowClone=true;
+                    var dragCloneData = obj.dragCloneData;
+                    var toCloneGroup = dragCloneData.group;
+                    _allowClone = (toCloneGroup === null && _group === null) || toCloneGroup === _group;
                     if(angular.isDefined(obj.data.allowClone)){
                         _allowClone=obj.data.allowClone;
                     }
                     if(_allowClone) {
+                        var toCloneElm = angular.element(obj.element[0]);
+
+                        if(dragCloneData.copyHtml && _copyHtml)
+                        {
+                            _copyHtmlElement.html(toCloneElm.html());
+                            _didCopyHtml = true;
+                        }
+
+                        if(dragCloneData.copyClass && _copyClass)
+                        {
+                            element.addClass(toCloneElm.attr("class"));
+                            _didCopyClass = true;
+                        }
+
+                        element.addClass(dragCloneData.addClass);
+                        scope.clonedGroup = toCloneGroup;
                         scope.$apply(function () {
                             scope.clonedData = obj.data;
                         });
                         element.css('width', obj.element[0].offsetWidth);
                         element.css('height', obj.element[0].offsetHeight);
+
+                        if (_hideOnClone && dragCloneData.hideOnClone)
+                        {
+                            toCloneElm.css("visibility", "hidden");
+                            _didHide = true;
+                        }
 
                         moveElement(obj.tx, obj.ty);
                     }
@@ -473,11 +604,29 @@ angular.module("ngDraggable", [])
                 var onDragEnd = function(evt, obj) {
                     //moveElement(obj.tx,obj.ty);
                     if(_allowClone) {
-                        reset();
+                        reset(obj);
                     }
                 };
 
-                var reset = function() {
+                var onDragEnterDrop = function(evt, args)
+                {
+                    element.addClass("drag-over");
+                }
+
+                var onDragLeaveDrop = function(evt, args)
+                {
+                    element.removeClass("drag-over");
+                }
+
+                var reset = function(obj) {
+                    if(_didCopyHtml)
+                    {
+                        _copyHtmlElement.html(_baseHTML);
+                    }
+                    if(_didCopyClass)
+                        element.attr("class", _baseClass);
+                    if(_didHide)
+                        angular.element(obj.element[0]).css("visibility", "");
                     element.css({left:0,top:0, position:'fixed', 'z-index':-1, visibility:'hidden'});
                 };
                 var moveElement = function(x,y) {
@@ -538,26 +687,33 @@ angular.module("ngDraggable", [])
     .directive('ngCancelDrag', [function () {
         return {
             restrict: 'A',
-            priority: 1,
             link: function (scope, element, attrs) {
                 element.find('*').attr('ng-cancel-drag', 'ng-cancel-drag');
             }
         };
     }])
-    .directive('ngDragScroll', ['$window', '$interval', '$timeout', '$document', '$rootScope', function($window, $interval, $timeout, $document, $rootScope) {
+    .directive('ngDragScroll', ['$window', '$interval', '$timeout', '$document', '$rootScope', 'ngDragHitTest', function($window, $interval, $timeout, $document, $rootScope, ngDragHitTest) {
         return {
             restrict: 'A',
             link: function(scope, element, attrs) {
                 var intervalPromise = null;
                 var lastMouseEvent = null;
+                var lastDragObj = null;
 
-                var scrollContainer = angular.isDefined(attrs.ngDragScrollContainer) ? angular.element(attrs.ngDragScrollContainer)[0] : null;
                 var config = {
                     verticalScroll: attrs.verticalScroll || true,
                     horizontalScroll: attrs.horizontalScroll || true,
                     activationDistance: attrs.activationDistance || 75,
-                    scrollDistance: attrs.scrollDistance || 25
+                    scrollDistance: attrs.scrollDistance || 15,
+                    scrollelement: null //It's the window itself :)
                 };
+
+                if (attrs.scrollElement)
+                {
+                    var foundElement = angular.element( document.querySelector( attrs.scrollElement ) );
+                    if (foundElement && foundElement.length > 0)
+                        config.scrollElements = foundElement;
+                }
 
 
                 var reqAnimFrame = (function() {
@@ -570,6 +726,7 @@ angular.module("ngDraggable", [])
                             window.setTimeout(callback, 1000 / 60);
                         };
                 })();
+
 
                 var animationIsOn = false;
                 var createInterval = function() {
@@ -590,75 +747,119 @@ angular.module("ngDraggable", [])
                     nextFrame(function() {
                         if (!lastMouseEvent) return;
 
-                        var viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-                        var viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+                        // lastMouseEvent.clientX is undefined when dealing with a touch device, resulting in
+                        // no scrolling when dragging an item to the bottom of the screen
+                        // Seen on Chrome 47.0.2526.111
+                        var clientX = lastMouseEvent.clientX;
+                        if (angular.isUndefined(lastMouseEvent.clientX))
+                            clientX = lastMouseEvent.touches[0].clientX;
 
-                        if (scrollContainer) {
-                            viewportHeight = scrollContainer.clientHeight;
+                        // lastMouseEvent.clientY is undefined when dealing with a touch device, resulting in
+                        // no scrolling when dragging an item to the bottom of the screen
+                        // Seen on Chrome 47.0.2526.111
+                        var clientY = lastMouseEvent.clientY;
+                        if (angular.isUndefined(lastMouseEvent.clientY))
+                            clientY = lastMouseEvent.touches[0].clientY;
+
+                        var hoverElements = ["window"]; //Later, create a variable to check if the user want to scroll the window or not.
+                        if(config.scrollElements)
+                        {
+                            var sides = {
+                                "all"    : {"distance" : config.activationDistance}
+                            };
+                            angular.forEach(config.scrollElements, function(testElement){ //Generate the hittest for each element
+                                var dragHitTestResult = ngDragHitTest(testElement, lastDragObj.x, lastDragObj.y, sides);
+                                if(dragHitTestResult.inside)
+                                {
+                                    hoverElements.push({"element" : testElement, "hitTestResult" : dragHitTestResult});
+                                }
+                            });
                         }
 
-                        var scrollX = 0;
-                        var scrollY = 0;
+                        var moved = false;
+                        angular.forEach(hoverElements, function(hoverElem)
+                        {
+                            var isWindow = (hoverElem === "window");
+                            var scrollX = 0;
+                            var scrollY = 0;
 
-                        if (config.horizontalScroll) {
-                            // If horizontal scrolling is active.
-                            if (lastMouseEvent.clientX < config.activationDistance) {
-                                // If the mouse is on the left of the viewport within the activation distance.
-                                scrollX = -config.scrollDistance;
-                            }
-                            else if (lastMouseEvent.clientX > viewportWidth - config.activationDistance) {
-                                // If the mouse is on the right of the viewport within the activation distance.
-                                scrollX = config.scrollDistance;
-                            }
-                        }
-
-                        if (config.verticalScroll) {
-                            // If vertical scrolling is active.
-                            if ((lastMouseEvent.clientY - (scrollContainer ? scrollContainer.getBoundingClientRect().top : 0)) < config.activationDistance) {
-                                // If the mouse is on the top of the viewport within the activation distance.
-                                scrollY = -config.scrollDistance;
-                            }
-                            else if (lastMouseEvent.clientY > ((scrollContainer ? scrollContainer.getBoundingClientRect().top : 0) + viewportHeight) - config.activationDistance) {
-                                // If the mouse is on the bottom of the viewport within the activation distance.
-                                scrollY = config.scrollDistance;
-                            }
-                        }
-
-                        if (scrollX !== 0 || scrollY !== 0) {
-                            // Record the current scroll position.
-                            var currentScrollLeft = ($window.pageXOffset || $document[0].documentElement.scrollLeft);
-                            var currentScrollTop = ($window.pageYOffset || $document[0].documentElement.scrollTop);
-
-                            if (scrollContainer) {
-                                currentScrollTop = scrollContainer.scrollTop;
-                            }
-                            // Remove the transformation from the element, scroll the window by the scroll distance
-                            // record how far we scrolled, then reapply the element transformation.
-                            var elementTransform = element.css('transform');
-                            element.css('transform', 'initial');
-
-                            if (scrollContainer) {
-                                scrollContainer.scrollTop += scrollY;
-                            } else {
-                                $window.scrollBy(scrollX, scrollY);
+                            if (config.horizontalScroll) {
+                                if(isWindow)
+                                {
+                                    // If horizontal scrolling is active.
+                                    var scrollXEnd = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+                                    if (clientX < config.activationDistance) // If the mouse is on the left of the viewport within the activation distance.
+                                        scrollX = -config.scrollDistance;
+                                    else if (clientX > scrollXEnd - config.activationDistance)// If the mouse is on the right of the viewport within the activation distance.
+                                        scrollX = config.scrollDistance;
+                                }
+                                else if (hoverElem.hitTestResult.right) //It's an element and it's on its right edge
+                                {
+                                    scrollX = config.scrollDistance;
+                                }
+                                else if(hoverElem.hitTestResult.left) //It's an element and it's on its left edge
+                                {
+                                    scrollX = -config.scrollDistance;
+                                }
                             }
 
-
-                            var horizontalScrollAmount = ($window.pageXOffset || $document[0].documentElement.scrollLeft) - currentScrollLeft;
-                            var verticalScrollAmount = ($window.pageYOffset || $document[0].documentElement.scrollTop) - currentScrollTop;
-                            if (scrollContainer) {
-                                verticalScrollAmount = (scrollContainer.scrollTop) - currentScrollTop;
+                            if (config.verticalScroll) {
+                                if (isWindow)
+                                {
+                                    var scrollYEnd = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+                                    // If vertical scrolling is active.
+                                    if (clientY < config.activationDistance) {
+                                        // If the mouse is on the top of the viewport within the activation distance.
+                                        scrollY = -config.scrollDistance;
+                                    }
+                                    else if (clientY > scrollYEnd - config.activationDistance) {
+                                        // If the mouse is on the bottom of the viewport within the activation distance.
+                                        scrollY = config.scrollDistance;
+                                    }
+                                }
+                                else if (hoverElem.hitTestResult.top) //It's an element and it's on its right edge
+                                {
+                                    scrollY = -config.scrollDistance;
+                                }
+                                else if(hoverElem.hitTestResult.bottom) //It's an element and it's on its left edge
+                                {
+                                    scrollY = config.scrollDistance;
+                                }
                             }
 
-                            element.css('transform', elementTransform);
+                            if (scrollX !== 0 || scrollY !== 0) {
+                                moved = true;
 
-                            lastMouseEvent.pageX += horizontalScrollAmount;
-                            lastMouseEvent.pageY += verticalScrollAmount;
+                                // Remove the transformation from the element, scroll the window by the scroll distance
+                                // record how far we scrolled, then reapply the element transformation.
+                                var elementTransform = element.css('transform');
+                                element.css('transform', 'initial');
 
+                                if(isWindow){
+                                    $window.scrollBy(scrollX, scrollY);
+                                    // Record the current scroll position.
+                                    var currentScrollLeft = ($window.pageXOffset || $document[0].documentElement.scrollLeft);
+                                    var currentScrollTop = ($window.pageYOffset || $document[0].documentElement.scrollTop);
+
+                                    var horizontalScrollAmount = ($window.pageXOffset || $document[0].documentElement.scrollLeft) - currentScrollLeft;
+                                    var verticalScrollAmount =  ($window.pageYOffset || $document[0].documentElement.scrollTop) - currentScrollTop;
+
+                                    lastMouseEvent.pageX += horizontalScrollAmount;
+                                    lastMouseEvent.pageY += verticalScrollAmount;
+                                }
+                                else {
+                                    var elementToMove = angular.element(hoverElem.element);
+                                    elementToMove[0].scrollTop = elementToMove[0].scrollTop + scrollY;
+                                    elementToMove[0].scrollLeft = elementToMove[0].scrollLeft + scrollX;
+                                }
+                                //reaply the element transfrom
+                                element.css('transform', elementTransform);
+                            }
+                        });//End angular forEach
+
+                        if (moved)
                             $rootScope.$emit('draggable:_triggerHandlerMove', lastMouseEvent);
-                        }
-
-                    });
+                    }); //End nextFrame
                 };
 
                 var clearInterval = function() {
@@ -684,6 +885,7 @@ angular.module("ngDraggable", [])
                     if (obj.element[0] !== element[0]) return;
 
                     lastMouseEvent = obj.event;
+                    lastDragObj = obj;
                 });
             }
         };

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -622,7 +622,7 @@ angular.module("ngDraggable", [])
                             }
                             else if (lastMouseEvent.clientY > (scrollContainer
                                     ? scrollContainer.getBoundingClientRect().bottom
-                                    : viewportHeight - config.activationDistance)) {
+                                    : (viewportHeight - config.activationDistance))) {
                                 // If the mouse is on the bottom of the viewport within the activation distance.
                                 scrollY = config.scrollDistance;
                             }

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -560,7 +560,6 @@ angular.module("ngDraggable", [])
                     scrollDistance: attrs.scrollDistance || 25
                 };
 
-
                 var reqAnimFrame = (function() {
                     return window.requestAnimationFrame ||
                         window.webkitRequestAnimationFrame ||
@@ -615,15 +614,20 @@ angular.module("ngDraggable", [])
 
                         if (config.verticalScroll) {
                             // If vertical scrolling is active.
-                            if ((lastMouseEvent.clientY - (scrollContainer ? scrollContainer.getBoundingClientRect().top : 0)) < config.activationDistance) {
+                            if (lastMouseEvent.clientY < (scrollContainer
+                                    ? scrollContainer.getBoundingClientRect().top
+                                    : config.activationDistance)) {
                                 // If the mouse is on the top of the viewport within the activation distance.
                                 scrollY = -config.scrollDistance;
                             }
-                            else if (lastMouseEvent.clientY > ((scrollContainer ? scrollContainer.getBoundingClientRect().top : 0) + viewportHeight) - config.activationDistance) {
+                            else if (lastMouseEvent.clientY > (scrollContainer
+                                    ? scrollContainer.getBoundingClientRect().bottom
+                                    : viewportHeight - config.activationDistance)) {
                                 // If the mouse is on the bottom of the viewport within the activation distance.
                                 scrollY = config.scrollDistance;
                             }
                         }
+
 
                         if (scrollX !== 0 || scrollY !== 0) {
                             // Record the current scroll position.

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -195,7 +195,9 @@ angular.module("ngDraggable", [])
                     if (!element.hasClass('dragging')) {
                         _data = getDragData(scope);
                         element.addClass('dragging');
-                        _scrolled = scrollContainer.scrollTop > 0;
+                        if (scrollContainer) {
+                            _scrolled = scrollContainer.scrollTop > 0;
+                        }
                         $rootScope.$broadcast('draggable:start', {x:_mx, y:_my, tx:_tx, ty:_ty, event:evt, element:element, data:_data});
                         if (onDragStartCallback ){
                             scope.$apply(function () {
@@ -215,7 +217,7 @@ angular.module("ngDraggable", [])
                         _ty = _my - _mry - _dragOffset.top;
                     }
 
-                    if (!_scrolled) {
+                    if (scrollContainer && !_scrolled) {
                         _ty += scrollContainer.scrollTop;
                     }
                     moveElement(_tx, _ty);
@@ -591,12 +593,8 @@ angular.module("ngDraggable", [])
                         var viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
                         var viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
 
-                        // if scrollContainer exists
-                        let scrollContainerJQuery;
-
                         if (scrollContainer) {
-                            scrollContainerJQuery = angular.element(scrollContainer);
-                            viewportHeight = scrollContainerJQuery.height();
+                            viewportHeight = scrollContainer.clientHeight;
                         }
 
                         var scrollX = 0;
@@ -616,11 +614,11 @@ angular.module("ngDraggable", [])
 
                         if (config.verticalScroll) {
                             // If vertical scrolling is active.
-                            if ((lastMouseEvent.clientY - (scrollContainer ? scrollContainerJQuery.offset().top : 0)) < config.activationDistance) {
+                            if ((lastMouseEvent.clientY - (scrollContainer ? scrollContainer.getBoundingClientRect().top : 0)) < config.activationDistance) {
                                 // If the mouse is on the top of the viewport within the activation distance.
                                 scrollY = -config.scrollDistance;
                             }
-                            else if (lastMouseEvent.clientY > ((scrollContainer ? scrollContainerJQuery.offset().top : 0) + viewportHeight) - config.activationDistance) {
+                            else if (lastMouseEvent.clientY > ((scrollContainer ? scrollContainer.getBoundingClientRect().top : 0) + viewportHeight) - config.activationDistance) {
                                 // If the mouse is on the bottom of the viewport within the activation distance.
                                 scrollY = config.scrollDistance;
                             }
@@ -656,7 +654,7 @@ angular.module("ngDraggable", [])
 
                             lastMouseEvent.pageX += horizontalScrollAmount;
                             lastMouseEvent.pageY += verticalScrollAmount;
-                            
+
                             $rootScope.$emit('draggable:_triggerHandlerMove', lastMouseEvent);
                         }
 


### PR DESCRIPTION
ran into an issue where children didn't get the ng-cancel-attribute because the ngCancelDrag's link function was executed before the other directive (in my case md-button from angular material). priority 1 asserts that the link function will be executed after other directives with default priority. maybe this is related to #57 
