### PR TITLE
Supporting canceling by data-ng-cancel-drag on element itself

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -517,7 +517,7 @@ angular.module("ngDraggable", [])
         return {
             restrict: 'A',
             link: function (scope, element, attrs) {
-                element.find('*').attr('ng-cancel-drag', 'ng-cancel-drag');
+                element.find('*').add(element).attr('ng-cancel-drag', 'ng-cancel-drag');
             }
         };
     }])


### PR DESCRIPTION
If element (for example a[href]) has [data-ng-cancel-drag] instead of [ng-cancel-drag] it will be ignored for canceling effect (only child elements would be affected).