### PR TITLE
Adding module.exports to enable es6 syntax: import ngDraggable from '…

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -659,3 +659,7 @@ angular.module("ngDraggable", [])
             }
         };
     }]);
+
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
+    module.exports = 'ngDraggable';
+}


### PR DESCRIPTION
…ngDraggable'